### PR TITLE
Fixing consent manager white screen issue

### DIFF
--- a/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/App.js
+++ b/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/App.js
@@ -22,10 +22,6 @@ import "./css/App.css";
 import { Login } from "./login/login.js";
 import { ResponseError } from "./errorPage/index.js";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
-import { logout } from "./login/logout.js";
-import { User } from "./data/User";
-
-const idToken = User.idToken;
 
 export const App = () => {
   return (
@@ -33,7 +29,6 @@ export const App = () => {
       <Switch>
         <Route path="/consentmgr" exact component={Login} />
         <Route path="/consentmgr/error" exact component={ResponseError} />
-        <Route path="/consentmgr/logout" exact component={() => logout(User?.idToken)} />
       </Switch>
     </Router>
   );

--- a/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/servlet/OAuthCallbackServlet.java
+++ b/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/servlet/OAuthCallbackServlet.java
@@ -59,7 +59,6 @@ public class OAuthCallbackServlet extends HttpServlet {
             if (StringUtils.isEmpty(code)) {
                 LOG.debug("Logout callback request received. Invalidating cookies.");
                 oAuthService.removeAllCookiesFromRequest(req, resp);
-                redirectUrl  += "/logout";
             } else {
                 LOG.debug("Authorization callback request received");
                 final String clientKey = Utils.getParameter(Constants.CONFIGURED_CLIENT_ID);


### PR DESCRIPTION
## Fixing consent manager white screen issue

> This PR fixes consent manager white screen issue and logout issue.

**Issue**: 

- https://github.com/wso2/financial-services-accelerator/issues/134

When the `consentmgr.war` is built from the open source accelerator repo and deployed, and go to `https://localhost:9446/consentmgr/` there is a white screen coming. 

This is due to an attempt to get an id_token to a user which is not initialized. This PR fixes this.


------

### Development Checklist

1. [X] Build complete solution with pull request in place.
2. [X] Ran checkstyle plugin with pull request in place.
3. [X] Ran Findbugs plugin with pull request in place.
4. [X] Ran FindSecurityBugs plugin and verified report.
5. [X] Formatted code according to WSO2 code style.
6. [X] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [X] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?
