### PR TITLE
Fix jsonConverter duplicate entry issue in configure.sh

### DIFF
--- a/open-banking-accelerator/accelerators/ob-apim/bin/configure.sh
+++ b/open-banking-accelerator/accelerators/ob-apim/bin/configure.sh
@@ -134,7 +134,9 @@ create_mysql_database_tables() {
 };
 
 add_json_fault_sequence() {
-  sed -i -e 's|</sequence>|\t<sequence key="jsonConverter"/>\n</sequence>|g' ${WSO2_OB_APIM_HOME}/repository/deployment/server/synapse-configs/default/sequences/_cors_request_handler_.xml
+    if ! grep -q '<sequence key="jsonConverter"/>' ${WSO2_OB_APIM_HOME}/repository/deployment/server/synapse-configs/default/sequences/_cors_request_handler_.xml; then
+    sed -i -e 's|</sequence>|\t<sequence key="jsonConverter"/>\n</sequence>|g' ${WSO2_OB_APIM_HOME}/repository/deployment/server/synapse-configs/default/sequences/_cors_request_handler_.xml
+    fi
 }
 
 echo -e "\nReplace hostnames \n"


### PR DESCRIPTION
## Fix jsonConverter duplicate entry issue in config.sh

> When running obam accelerator config.sh multiple times, `<sequence key="jsonConverter"/>` entry in `_cors_request_handler_.xml` is repeated. This PR fixes this.

**Issue link:** 
- https://github.com/wso2/financial-services-accelerator/issues/145

**Applicable Labels:** OB3 Accelerator

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
