### PR TITLE
Fix tokens not revoking issue

### DIFF
--- a/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
+++ b/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
@@ -2584,7 +2584,7 @@ public class ConsentCoreServiceImpl implements ConsentCoreService {
                 // Filter tokens by consent ID claim
                 if (Arrays.asList(accessTokenDO.getScope()).contains(consentIdClaim +
                         detailedConsentResource.getConsentID())) {
-                    activeTokens.add(accessTokenDO.getAccessToken());
+                    activeTokens.add(accessTokenDO.getRefreshToken());
                 }
             }
 


### PR DESCRIPTION
## Fix tokens not revoking issue

> Tokens are not revoked after arrangement revoke request. Eventhough the token type is set as `refresh_token`, the access_token is passed to IS `revokeTokenByOAuthClient` method. This PR fixes this by passing `refresh_token`.

## Related Issues
- https://github.com/wso2-enterprise/wso2-ob-internal/issues/898


**Applicable Labels:** CDS Toolkit

------

### Development Checklist

1. [X] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
