### PR TITLE
[OB3] Fix issue in FAPI test suite when sending request object without exp claim

### DIFF
--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/FapiRequestObjectValidator.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/FapiRequestObjectValidator.java
@@ -22,6 +22,7 @@ import com.wso2.openbanking.accelerator.common.validator.OpenBankingValidator;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.FapiRequestObject;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.OBRequestObject;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.ValidationResponse;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationorder.ValidationOrder;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Map;
@@ -38,7 +39,8 @@ public class FapiRequestObjectValidator extends DefaultOBRequestObjectValidator 
 
         if (superValidationResponse.isValid()) {
             FapiRequestObject fapiRequestObject = new FapiRequestObject(obRequestObject);
-            String violation = OpenBankingValidator.getInstance().getFirstViolation(fapiRequestObject);
+            String violation = OpenBankingValidator.getInstance().getFirstViolation(fapiRequestObject,
+                    ValidationOrder.class);
 
             if (StringUtils.isEmpty(violation)) {
                 return new ValidationResponse(true);

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/OBRequestObjectValidator.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/OBRequestObjectValidator.java
@@ -21,6 +21,7 @@ package com.wso2.openbanking.accelerator.identity.auth.extensions.request.valida
 import com.wso2.openbanking.accelerator.common.validator.OpenBankingValidator;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.OBRequestObject;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.ValidationResponse;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationorder.ValidationOrder;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Map;
@@ -39,7 +40,7 @@ public class OBRequestObjectValidator {
      */
     public ValidationResponse validateOBConstraints(OBRequestObject obRequestObject, Map<String, Object> dataMap) {
 
-        String violation = OpenBankingValidator.getInstance().getFirstViolation(obRequestObject);
+        String violation = OpenBankingValidator.getInstance().getFirstViolation(obRequestObject, ValidationOrder.class);
 
         if (StringUtils.isEmpty(violation)) {
             return new ValidationResponse(true);

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/models/FapiRequestObject.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/models/FapiRequestObject.java
@@ -22,20 +22,23 @@ import com.wso2.openbanking.accelerator.common.validator.annotation.RequiredPara
 import com.wso2.openbanking.accelerator.common.validator.annotation.RequiredParameters;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.annotations.ValidExpiration;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.annotations.ValidNbfExpClaims;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.AttributeChecks;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.MandatoryChecks;
 
 /**
  * Model class for FAPI request object.
  */
 @RequiredParameters({
         @RequiredParameter(param = "claimsSet.claims.redirect_uri",
-                message = "Mandatory parameter redirect_uri, not found in the request"),
+                message = "Mandatory parameter redirect_uri, not found in the request", groups = MandatoryChecks.class),
         @RequiredParameter(param = "claimsSet.claims.nonce",
-                message = "nonce parameter is missing in the request object"),
+                message = "nonce parameter is missing in the request object", groups = MandatoryChecks.class),
         @RequiredParameter(param = "claimsSet.claims.exp",
-                message = "exp parameter is missing in the request object")
+                message = "exp parameter is missing in the request object", groups = MandatoryChecks.class)
 })
-@ValidExpiration(expiration = "claimsSet.claims.exp")
-@ValidNbfExpClaims(notBefore = "claimsSet.claims.nbf", expiration = "claimsSet.claims.exp")
+@ValidExpiration(expiration = "claimsSet.claims.exp", groups = AttributeChecks.class)
+@ValidNbfExpClaims(notBefore = "claimsSet.claims.nbf", expiration = "claimsSet.claims.exp",
+        groups = AttributeChecks.class)
 public class FapiRequestObject extends OBRequestObject {
 
     private static final long serialVersionUID = -83973857804232423L;

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/models/OBRequestObject.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/models/OBRequestObject.java
@@ -26,6 +26,8 @@ import com.wso2.openbanking.accelerator.common.validator.annotation.RequiredPara
 import com.wso2.openbanking.accelerator.common.validator.annotation.ValidAudience;
 import com.wso2.openbanking.accelerator.common.validator.annotation.ValidScopeFormat;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.annotations.ValidSigningAlgorithm;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.AttributeChecks;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.MandatoryChecks;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
 import org.wso2.carbon.identity.openidconnect.model.RequestedClaim;
@@ -40,13 +42,15 @@ import java.util.Map;
  */
 @RequiredParameters({
         @RequiredParameter(param = "signedJWT",
-                message = "Only Signed JWS is accepted for request object"),
+                message = "Only Signed JWS is accepted for request object", groups = MandatoryChecks.class),
         @RequiredParameter(param = "claimsSet.claims.aud",
-                message = "aud parameter is missing in the request object")
+                message = "aud parameter is missing in the request object", groups = MandatoryChecks.class)
 })
-@ValidScopeFormat(scope = "claimsSet.claims.scope")
-@ValidAudience(audience = "claimsSet.claims.aud", clientId = "claimsSet.claims.client_id")
-@ValidSigningAlgorithm(algorithm = "signedJWT.header.algorithm.name", clientId = "claimsSet.claims.client_id")
+@ValidScopeFormat(scope = "claimsSet.claims.scope", groups = AttributeChecks.class)
+@ValidAudience(audience = "claimsSet.claims.aud", clientId = "claimsSet.claims.client_id",
+        groups = AttributeChecks.class)
+@ValidSigningAlgorithm(algorithm = "signedJWT.header.algorithm.name", clientId = "claimsSet.claims.client_id",
+        groups = AttributeChecks.class)
 public class OBRequestObject<T extends OBRequestObject> extends RequestObject {
 
     // decorator object

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/common/annotations/validationorder/ValidationOrder.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/common/annotations/validationorder/ValidationOrder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,7 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.wso2.openbanking.accelerator.identity.dcr.validation.validationorder;
+
+package com.wso2.openbanking.accelerator.identity.common.annotations.validationorder;
 
 import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.AttributeChecks;
 import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.MandatoryChecks;

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/utils/ValidatorUtils.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/utils/ValidatorUtils.java
@@ -19,9 +19,9 @@ package com.wso2.openbanking.accelerator.identity.dcr.utils;
 
 import com.wso2.openbanking.accelerator.common.util.Generated;
 import com.wso2.openbanking.accelerator.common.validator.OpenBankingValidator;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationorder.ValidationOrder;
 import com.wso2.openbanking.accelerator.identity.dcr.exception.DCRValidationException;
 import com.wso2.openbanking.accelerator.identity.dcr.model.RegistrationRequest;
-import com.wso2.openbanking.accelerator.identity.dcr.validation.validationgroups.ValidationOrder;
 import com.wso2.openbanking.accelerator.identity.internal.IdentityExtensionsDataHolder;
 import com.wso2.openbanking.accelerator.identity.util.IdentityCommonConstants;
 import com.wso2.openbanking.accelerator.identity.util.IdentityCommonUtil;

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/DefaultOBRequestObjectValidatorTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/DefaultOBRequestObjectValidatorTest.java
@@ -78,7 +78,8 @@ public class DefaultOBRequestObjectValidatorTest extends PowerMockTestCase {
         doReturn(consentResourceMock).when(consentCoreServiceMock).getDetailedConsent(anyString());
 
         OpenBankingValidator openBankingValidatorMock = mock(OpenBankingValidator.class);
-        doReturn("").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject());
+        doReturn("").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject(),
+                Mockito.anyObject());
 
         PowerMockito.mockStatic(OpenBankingValidator.class);
         PowerMockito.when(OpenBankingValidator.getInstance()).thenReturn(openBankingValidatorMock);
@@ -103,7 +104,8 @@ public class DefaultOBRequestObjectValidatorTest extends PowerMockTestCase {
         doReturn(consentResourceMock).when(consentCoreServiceMock).getDetailedConsent(anyString());
 
         OpenBankingValidator openBankingValidatorMock = mock(OpenBankingValidator.class);
-        doReturn("").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject());
+        doReturn("").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject(),
+                Mockito.anyObject());
 
         PowerMockito.mockStatic(OpenBankingValidator.class);
         PowerMockito.when(OpenBankingValidator.getInstance()).thenReturn(openBankingValidatorMock);
@@ -125,7 +127,8 @@ public class DefaultOBRequestObjectValidatorTest extends PowerMockTestCase {
     public void testValidateOBConstraintsWhenOBRequestObjectHasErrors() throws Exception {
         // mock
         OpenBankingValidator openBankingValidatorMock = mock(OpenBankingValidator.class);
-        doReturn("dummy-error").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject());
+        doReturn("dummy-error").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject(),
+                Mockito.anyObject());
 
         PowerMockito.mockStatic(OpenBankingValidator.class);
         PowerMockito.when(OpenBankingValidator.getInstance()).thenReturn(openBankingValidatorMock);

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/FapiRequestObjectValidatorTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/FapiRequestObjectValidatorTest.java
@@ -22,7 +22,7 @@ import com.wso2.openbanking.accelerator.common.exception.ConsentManagementExcept
 import com.wso2.openbanking.accelerator.common.validator.OpenBankingValidator;
 import com.wso2.openbanking.accelerator.consent.mgt.dao.models.DetailedConsentResource;
 import com.wso2.openbanking.accelerator.consent.mgt.service.impl.ConsentCoreServiceImpl;
-import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.OBRequestObject;
+import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.FapiRequestObject;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.ValidationResponse;
 import com.wso2.openbanking.accelerator.identity.internal.IdentityExtensionsDataHolder;
 import com.wso2.openbanking.accelerator.identity.utils.TestUtils;
@@ -74,7 +74,8 @@ public class FapiRequestObjectValidatorTest extends PowerMockTestCase {
         doReturn(consentResourceMock).when(consentCoreServiceMock).getDetailedConsent(anyString());
 
         OpenBankingValidator openBankingValidatorMock = mock(OpenBankingValidator.class);
-        doReturn("").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject());
+        doReturn("").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject(),
+                Mockito.anyObject());
 
         PowerMockito.mockStatic(OpenBankingValidator.class);
         PowerMockito.when(OpenBankingValidator.getInstance()).thenReturn(openBankingValidatorMock);
@@ -82,7 +83,8 @@ public class FapiRequestObjectValidatorTest extends PowerMockTestCase {
         // act
         FapiRequestObjectValidator uut = new FapiRequestObjectValidator();
 
-        OBRequestObject<?> obRequestObject = TestUtils.getObRequestObject(ReqObjectTestDataProvider.REQUEST_STRING);
+        FapiRequestObject obRequestObject = TestUtils
+                .getFapiRequestObject(ReqObjectTestDataProvider.VALID_FAPI_REQUEST_OBJ);
         ValidationResponse validationResponse = uut.validateOBConstraints(obRequestObject, Collections.emptyMap());
 
         // assert
@@ -98,7 +100,8 @@ public class FapiRequestObjectValidatorTest extends PowerMockTestCase {
         doReturn(consentResourceMock).when(consentCoreServiceMock).getDetailedConsent(anyString());
 
         OpenBankingValidator openBankingValidatorMock = mock(OpenBankingValidator.class);
-        doReturn("dummy-error").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject());
+        doReturn("dummy-error").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject(),
+                Mockito.anyObject());
 
         PowerMockito.mockStatic(OpenBankingValidator.class);
         PowerMockito.when(OpenBankingValidator.getInstance()).thenReturn(openBankingValidatorMock);
@@ -106,8 +109,34 @@ public class FapiRequestObjectValidatorTest extends PowerMockTestCase {
         // act
         FapiRequestObjectValidator uut = new FapiRequestObjectValidator();
 
-        OBRequestObject<?> obRequestObject = TestUtils
-                .getObRequestObject(ReqObjectTestDataProvider.NO_CLIENT_ID_REQUEST);
+        FapiRequestObject obRequestObject = TestUtils
+                .getFapiRequestObject(ReqObjectTestDataProvider.FAPI_REQ_OBJ_WITHOUT_CLIENT_ID);
+        ValidationResponse validationResponse = uut.validateOBConstraints(obRequestObject, Collections.emptyMap());
+
+        // assert
+        Assert.assertFalse(validationResponse.isValid());
+    }
+
+    @Test
+    public void testValidateOBConstraintsWithoutExpInRequestObject() throws Exception {
+        // mock
+        DetailedConsentResource consentResourceMock = mock(DetailedConsentResource.class);
+        doReturn(CLIENT_ID_1).when(consentResourceMock).getClientID();
+
+        doReturn(consentResourceMock).when(consentCoreServiceMock).getDetailedConsent(anyString());
+
+        OpenBankingValidator openBankingValidatorMock = mock(OpenBankingValidator.class);
+        doReturn("dummy-error").when(openBankingValidatorMock).getFirstViolation(Mockito.anyObject(),
+                Mockito.anyObject());
+
+        PowerMockito.mockStatic(OpenBankingValidator.class);
+        PowerMockito.when(OpenBankingValidator.getInstance()).thenReturn(openBankingValidatorMock);
+
+        // act
+        FapiRequestObjectValidator uut = new FapiRequestObjectValidator();
+
+        FapiRequestObject obRequestObject = TestUtils
+                .getFapiRequestObject(ReqObjectTestDataProvider.FAP_REQ_OBJ_WITHOUT_EXP);
         ValidationResponse validationResponse = uut.validateOBConstraints(obRequestObject, Collections.emptyMap());
 
         // assert

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/ReqObjectTestDataProvider.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/auth/extensions/request/validator/ReqObjectTestDataProvider.java
@@ -87,6 +87,45 @@ public class ReqObjectTestDataProvider {
             "0LE6jCVq_P6YrJvIbpZnMHL1wsgkJQzXoeu8HLN7kgwaYuUQesWIAWrFR26Ca7kcmRCmVqtj4Z2arhF2QQWtKUurrDYKcSxrQwZHRsQ" +
             "Zh76z6dULjhUfz7JQ5JIvtqooAA";
 
+    public static final String VALID_FAPI_REQUEST_OBJ = "eyJraWQiOiJjSVlvLTV6WDRPVFdacEhybW1pWkRWeEFDSk0iLCJhbGciOiJ" +
+            "QUzI1NiJ9.eyJhdWQiOiJodHRwczovL29iaWFtOjk0NDYvb2F1dGgyL3Rva2VuIiwibmJmIjoxNzM2MzE3NDg2LCJzY29wZSI6Im9wZ" +
+            "W5pZCBhY2NvdW50cyIsImNsYWltcyI6eyJpZF90b2tlbiI6eyJvcGVuYmFua2luZ19pbnRlbnRfaWQiOnsidmFsdWUiOiJjNTkyNzRm" +
+            "Yi1lZjRkLTRjNjktYTU0Yi1iM2EyYWU2MzljYjgiLCJlc3NlbnRpYWwiOnRydWV9LCJhY3IiOnsidmFsdWVzIjpbInVybjpvcGVuYmF" +
+            "ua2luZzpwc2QyOnNjYSIsInVybjpvcGVuYmFua2luZzpwc2QyOmNhIl0sImVzc2VudGlhbCI6dHJ1ZX19fSwiaXNzIjoiZjhaSkZCZz" +
+            "RkbXo4OGdmTFY1SGRDZnFFZnVvYSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIGlkX3Rva2VuIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6L" +
+            "y9sb2NhbGhvc3QuZW1vYml4LmNvLnVrOjg0NDMvdGVzdC9hL3dzbzJjYXJib24vY2FsbGJhY2siLCJzdGF0ZSI6IkdheTMyTnBSdDAi" +
+            "LCJleHAiOjE3MzYzMTc3ODYsIm5vbmNlIjoiVEtBbXFaSFEwUSIsImNsaWVudF9pZCI6ImY4WkpGQmc0ZG16ODhnZkxWNUhkQ2ZxRWZ" +
+            "1b2EifQ.XFM8Gn3ZMduJGTifix-gulACNBDVEIiHUuNf52JJg1f_5cN6YrpEf8Y3-yumaZwQ4SdQJIUhMH5k9CP48fbezXKWLhIHxSy" +
+            "UEziZF49OY-y_JB8HHtrtD2t3kUogyRlEzJZiQPkvK_VNzvAQuZ7pes4m5yPZp1zE_smF-UlrOhFgm5KB_VNcVDzWa2WkdDiTllk5kl" +
+            "UjQ03yB4CVUlL2Y7pJMfXx6X-OZe81ovh4n-qB_Nksf_zFCV6o0r6RmXg-80-SXkYYVgmK7tqzvTM5J4bWyZ2qJi12egBThMgpZrkAZ" +
+            "LDh4JbfcjB2D8n97ECH_7rr3swniUi9n5pSBuHkaw";
+
+    public static final String FAPI_REQ_OBJ_WITHOUT_CLIENT_ID = "eyJraWQiOiJjSVlvLTV6WDRPVFdacEhybW1pWkRWeEFDSk0iLCJ" +
+            "hbGciOiJQUzI1NiJ9.eyJhdWQiOiJodHRwczovL29iaWFtOjk0NDYvb2F1dGgyL3Rva2VuIiwibmJmIjoxNzM2MzE3NDg2LCJzY29wZ" +
+            "SI6Im9wZW5pZCBhY2NvdW50cyIsImNsYWltcyI6eyJpZF90b2tlbiI6eyJvcGVuYmFua2luZ19pbnRlbnRfaWQiOnsidmFsdWUiOiJj" +
+            "NTkyNzRmYi1lZjRkLTRjNjktYTU0Yi1iM2EyYWU2MzljYjgiLCJlc3NlbnRpYWwiOnRydWV9LCJhY3IiOnsidmFsdWVzIjpbInVybjp" +
+            "vcGVuYmFua2luZzpwc2QyOnNjYSIsInVybjpvcGVuYmFua2luZzpwc2QyOmNhIl0sImVzc2VudGlhbCI6dHJ1ZX19fSwiaXNzIjoiZj" +
+            "haSkZCZzRkbXo4OGdmTFY1SGRDZnFFZnVvYSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIGlkX3Rva2VuIiwicmVkaXJlY3RfdXJpIjoia" +
+            "HR0cHM6Ly9sb2NhbGhvc3QuZW1vYml4LmNvLnVrOjg0NDMvdGVzdC9hL3dzbzJjYXJib24vY2FsbGJhY2siLCJzdGF0ZSI6IkdheTMy" +
+            "TnBSdDAiLCJleHAiOjE3MzYzMTc3ODYsIm5vbmNlIjoiVEtBbXFaSFEwUSIsImNsaWVudF9pZCI6IiJ9.L-f1tTGNS_c2qJOunM7Wq7" +
+            "k51Fk9R1rR3xhRqjLjmEeQbv-Rc9MOnpxbWm1wE1_yLB3n9nKaMj9XdbGpFVCJAHrhxJSSMkhcI8RiyuXthaVFX1GymP5yxiSFUBy8G" +
+            "imp34gkhT1rkhaF4wnwR_nRZv-KVccoZYPUF8ez_fKzt5K30dDQKiT1AW7t8yMLzz2K0i7dRMs0m4cZZdHBk_ixPVx0IKlpRlg2YuPh" +
+            "rcFC1TlE4DCJyweebJbxiQbJeCyMvgTqURwigd5wbTanZ_FYyRSFDhkR-8PmpsH2UlytVg5zTxv_jRDqAkI3xcmIHCb6_aaajv6iGDF" +
+            "uyJqy1YvoNg";
+
+    public static final String FAP_REQ_OBJ_WITHOUT_EXP = "eyJraWQiOiJjSVlvLTV6WDRPVFdacEhybW1pWkRWeEFDSk0iLCJhbGciO" +
+            "iJQUzI1NiJ9.eyJhdWQiOiJodHRwczovL29iaWFtOjk0NDYvb2F1dGgyL3Rva2VuIiwibmJmIjoxNzM2MzEzMjQzLCJzY29wZSI6Im" +
+            "9wZW5pZCBhY2NvdW50cyIsImNsYWltcyI6eyJpZF90b2tlbiI6eyJvcGVuYmFua2luZ19pbnRlbnRfaWQiOnsidmFsdWUiOiIzYThj" +
+            "ZWViYS04ZmJkLTQ2ZDYtOWVhZi0wZjgzNTI5MjRmMDkiLCJlc3NlbnRpYWwiOnRydWV9LCJhY3IiOnsidmFsdWVzIjpbInVybjpvcG" +
+            "VuYmFua2luZzpwc2QyOnNjYSIsInVybjpvcGVuYmFua2luZzpwc2QyOmNhIl0sImVzc2VudGlhbCI6dHJ1ZX19fSwiaXNzIjoidmpu" +
+            "QzlxX19Ha1BJYmpOU3pwbnNDMGRPa3U4YSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIGlkX3Rva2VuIiwicmVkaXJlY3RfdXJpIjoiaH" +
+            "R0cHM6Ly9sb2NhbGhvc3QuZW1vYml4LmNvLnVrOjg0NDMvdGVzdC9hL3dzbzJjYXJib24vY2FsbGJhY2siLCJzdGF0ZSI6InN4UUtw" +
+            "ckRNWDEiLCJub25jZSI6IkNNRkVhUlZ6eUkiLCJjbGllbnRfaWQiOiJ2am5DOXFfX0drUEliak5TenBuc0MwZE9rdThhIn0.KchTgE" +
+            "eElHTYpM_1bHTqB-tZQXANSSS7A4zIQ3GYdnN_8MP_RxaCZ17HgQmZ8MxOpvIk2tzdRmo0OODmd21uEciC4j9Isf6vhQEZ1Tlnc0R1" +
+            "jtmEExjiX-OYkogan1_VjW5npdwhumDwN-GPSqutl0vQ8144x2XTXT0HnnkpE1TUT2lMtV019StXWNfgegSJ6Dnn7e8_aAvNPPAopA" +
+            "o9FBYG5nbxfetJRUH6-fbcaSwb4JOMhsb_DLFunYWgzBz1QYFCSOLEbj8zN7dIFEu7IG0ivGll1EkZMC_he99XHiL234RWX-NPI_dx" +
+            "Jpci0Wcn-SOyLwYGDU0ZpQVV48inSQ";
+
 
     @DataProvider(name = "dp-checkValidRequestObject")
     public Object[][] dpCheckValidRequestObject() throws ParseException, RequestObjectException {

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/utils/TestUtils.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/utils/TestUtils.java
@@ -22,6 +22,7 @@ import com.nimbusds.jose.JOSEObject;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.jwt.SignedJWT;
+import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.FapiRequestObject;
 import com.wso2.openbanking.accelerator.identity.auth.extensions.request.validator.models.OBRequestObject;
 import org.wso2.carbon.identity.oauth2.RequestObjectException;
 import org.wso2.carbon.identity.openidconnect.model.RequestObject;
@@ -50,6 +51,20 @@ public class TestUtils {
             requestObject.setSignedJWT(SignedJWT.parse(request));
         }
         return new OBRequestObject<>(requestObject);
+    }
+
+    /**
+     * Get FAPI request object.
+     *
+     * @param request request
+     * @return FapiRequestObject
+     * @throws ParseException
+     * @throws RequestObjectException
+     */
+    public static FapiRequestObject getFapiRequestObject(String request) throws ParseException,
+            RequestObjectException {
+        OBRequestObject<?> requestObject = getObRequestObject(request);
+        return new FapiRequestObject(requestObject);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,12 +69,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-clean-plugin</artifactId>
                         <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <phase>install</phase>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-clean-plugin</artifactId>
                         <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
+
             </build>
             <properties>
                 <npm.executable>npm</npm.executable>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
                         </configuration>
                     </plugin>
                 </plugins>
-
             </build>
             <properties>
                 <npm.executable>npm</npm.executable>


### PR DESCRIPTION
## [OB3] Fix issue in FAPI test suite when sending request object without exp claim

>  This PR fix issue in FAPI test suite when sending request object without exp claim. 
> Integration test PR - https://github.com/wso2-enterprise/bfsi-test-resources/pull/69

**Issue link:** https://github.com/wso2/financial-services-accelerator/issues/252

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *OB 3.0.0*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
