### PR TITLE
[OB4 - M4] Exclude consent type and path matching validation in extensions

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionUtils.java
@@ -22,7 +22,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
 import org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants;
-import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.common.exception.ConsentManagementRuntimeException;
 import org.wso2.financial.services.accelerator.common.util.Generated;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
@@ -48,7 +47,8 @@ public class ConsentExtensionUtils {
      * @param requestPath  Request path of the request
      * @return Consent Type
      */
-    public static String getConsentType(String requestPath) throws ConsentManagementException {
+    public static String getConsentType(String requestPath) throws ConsentException {
+
         if (requestPath.contains(ConsentExtensionConstants.ACCOUNT_CONSENT_PATH)) {
             return ConsentExtensionConstants.ACCOUNTS;
         } else if (requestPath.contains(ConsentExtensionConstants.COF_CONSENT_PATH)) {
@@ -56,7 +56,8 @@ public class ConsentExtensionUtils {
         } else if (requestPath.contains(ConsentExtensionConstants.PAYMENT_CONSENT_PATH)) {
             return ConsentExtensionConstants.PAYMENTS;
         } else {
-            throw new ConsentManagementException("Invalid consent type");
+            throw new ConsentException(ResponseStatus.BAD_REQUEST, "Invalid request path found.",
+                    ConsentOperationEnum.CONSENT_RETRIEVE);
         }
     }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
@@ -142,9 +142,9 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                 } else {
                     String consentType = ConsentExtensionUtils.getConsentType(consentManageData.getRequestPath());
                     if (!consentType.equals(consent.getConsentType())) {
-                        log.error("Consent Type mismatch");
-                        throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent Type mismatch",
-                                ConsentOperationEnum.CONSENT_RETRIEVE);
+                        log.error(ConsentManageConstants.CONSENT_TYPE_MISMATCH_ERROR);
+                        throw new ConsentException(ResponseStatus.BAD_REQUEST, ConsentManageConstants.
+                                CONSENT_TYPE_MISMATCH_ERROR, ConsentOperationEnum.CONSENT_RETRIEVE);
                     }
                     JSONObject receiptJSON = new JSONObject(consent.getReceipt());
                     consentManageData.setResponsePayload(ConsentExtensionUtils.getInitiationRetrievalResponse(
@@ -312,9 +312,9 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                 } else {
                     String consentType = ConsentExtensionUtils.getConsentType(consentManageData.getRequestPath());
                     if (!consentType.equals(consentResource.getConsentType())) {
-                        log.error("Consent Type mismatch");
-                        throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent Type mismatch",
-                                ConsentOperationEnum.CONSENT_DELETE);
+                        log.error(ConsentManageConstants.CONSENT_TYPE_MISMATCH_ERROR);
+                        throw new ConsentException(ResponseStatus.BAD_REQUEST, ConsentManageConstants.
+                                CONSENT_TYPE_MISMATCH_ERROR, ConsentOperationEnum.CONSENT_DELETE);
                     }
 
                     if (ConsentExtensionConstants.REVOKED_STATUS.equals(consentResource.getCurrentStatus()) ||

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
@@ -122,12 +122,6 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                     throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent not found",
                             ConsentOperationEnum.CONSENT_RETRIEVE);
                 }
-                String consentType = ConsentExtensionUtils.getConsentType(consentManageData.getRequestPath());
-                if (!consentType.equals(consent.getConsentType())) {
-                    log.error("Consent Type mismatch");
-                    throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent Type mismatch",
-                            ConsentOperationEnum.CONSENT_RETRIEVE);
-                }
                 // Check whether the client id is matching
                 if (!consent.getClientID().equals(consentManageData.getClientId())) {
                     log.error("Client ID mismatch");
@@ -146,6 +140,12 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                             callExternalService(requestDTO);
                     consentManageData.setResponsePayload(responseDTO.getResponseData());
                 } else {
+                    String consentType = ConsentExtensionUtils.getConsentType(consentManageData.getRequestPath());
+                    if (!consentType.equals(consent.getConsentType())) {
+                        log.error("Consent Type mismatch");
+                        throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent Type mismatch",
+                                ConsentOperationEnum.CONSENT_RETRIEVE);
+                    }
                     JSONObject receiptJSON = new JSONObject(consent.getReceipt());
                     consentManageData.setResponsePayload(ConsentExtensionUtils.getInitiationRetrievalResponse(
                             receiptJSON, consent));
@@ -290,13 +290,6 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                             ConsentOperationEnum.CONSENT_DELETE);
                 }
 
-                String consentType = ConsentExtensionUtils.getConsentType(consentManageData.getRequestPath());
-                if (!consentType.equals(consentResource.getConsentType())) {
-                    log.error("Consent Type mismatch");
-                    throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent Type mismatch",
-                            ConsentOperationEnum.CONSENT_DELETE);
-                }
-
                 if (!consentResource.getClientID().equals(consentManageData.getClientId())) {
                     //Throwing this error in a generic manner since client will not be able to identify if consent
                     // exists if consent does not belong to them
@@ -317,6 +310,13 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                     shouldRevokeTokens = responseDTO.getRequireTokenRevocation();
                     revocationStatusName = responseDTO.getRevocationStatusName();
                 } else {
+                    String consentType = ConsentExtensionUtils.getConsentType(consentManageData.getRequestPath());
+                    if (!consentType.equals(consentResource.getConsentType())) {
+                        log.error("Consent Type mismatch");
+                        throw new ConsentException(ResponseStatus.BAD_REQUEST, "Consent Type mismatch",
+                                ConsentOperationEnum.CONSENT_DELETE);
+                    }
+
                     if (ConsentExtensionConstants.REVOKED_STATUS.equals(consentResource.getCurrentStatus()) ||
                             ConsentExtensionConstants.REJECTED_STATUS.equals(consentResource.getCurrentStatus())) {
                         log.error("Consent is already in revoked or rejected state");

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ConsentManageConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ConsentManageConstants.java
@@ -24,4 +24,5 @@ package org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.ut
 public class ConsentManageConstants {
 
     public static final String NO_CONSENT_FOR_CLIENT_ERROR = "No valid consent found for given information";
+    public static final String CONSENT_TYPE_MISMATCH_ERROR = "Consent Type mismatch";
 }


### PR DESCRIPTION
## [OB4] Exclude consent type and path matching validation in extensions

> In default consent manage handler there is a validation in consent retrieval and revoke flows that checks whether request-uri matches with the consent type. This PR adds a fix to ignore that validation when the consent API extension is enabled. If the extension is enabled, such validations should be done in the toolkit.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/462*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
