### PR TITLE
[Accelerator 4] Add default non initiated consent flow 

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.dao/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/dao/impl/ConsentCoreDAOTests.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.dao/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/dao/impl/ConsentCoreDAOTests.java
@@ -2194,7 +2194,7 @@ public class ConsentCoreDAOTests {
             consentCoreDAO.storeConsentAttributes(connection, consentAttributesResource);
 
             expirationEligibleConsents = consentCoreDAO.getExpiringConsents(connection,
-                    "authorised,awaitingAuthorisation");
+                    "Authorised,AwaitingAuthorisation");
 
         }
         Assert.assertFalse(expirationEligibleConsents.isEmpty());

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.dao/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/dao/util/ConsentMgtDAOTestData.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.dao/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/dao/util/ConsentMgtDAOTestData.java
@@ -45,7 +45,7 @@ public class ConsentMgtDAOTestData {
     public static final String SAMPLE_CONSENT_ID = "2222";
     public static final String SAMPLE_AUTHORIZATION_ID = "3333";
     public static final boolean SAMPLE_RECURRING_INDICATOR = true;
-    public static final String SAMPLE_CURRENT_STATUS = "authorised";
+    public static final String SAMPLE_CURRENT_STATUS = "Authorised";
     public static final String  SAMPLE_PREVIOUS_STATUS = "Received";
     public static final String SAMPLE_AUTHORIZATION_TYPE = "authorizationType";
     public static final String SAMPLE_USER_ID = "admin@wso2.com";
@@ -106,9 +106,9 @@ public class ConsentMgtDAOTestData {
     };
     public static final ArrayList<String> SAMPLE_CONSENT_STATUSES_LIST = new ArrayList<String>() {
         {
-            add("created");
-            add("authorised");
-            add("awaitingAuthorisation");
+            add("Created");
+            add("Authorised");
+            add("AwaitingAuthorisation");
 
         }
     };

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentRetrievalStep.java
@@ -6,7 +6,7 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -22,6 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
+import org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants;
 import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.AuthorizationResource;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
@@ -31,56 +33,81 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.AuthErrorCode;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
-import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ResponseStatus;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.internal.ConsentExtensionsDataHolder;
 import org.wso2.financial.services.accelerator.consent.mgt.service.ConsentCoreService;
+
+import java.util.UUID;
 
 /**
  * Consent retrieval step default implementation.
  */
 public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
 
+    private final boolean isPreInitiatedConsent;
     private static final Log log = LogFactory.getLog(DefaultConsentRetrievalStep.class);
+
+    public DefaultConsentRetrievalStep() {
+
+        FinancialServicesConfigParser configParser = FinancialServicesConfigParser.getInstance();
+        isPreInitiatedConsent = configParser.isPreInitiatedConsent();
+    }
+
     @Override
     public void execute(ConsentData consentData, JSONObject jsonObject) throws ConsentException {
 
         if (!consentData.isRegulatory()) {
             return;
         }
-
         ConsentCoreService consentCoreService = ConsentExtensionsDataHolder.getInstance().getConsentCoreService();
+        JSONArray consentDataJSON;
+        ConsentResource consentResource;
 
         try {
+
             String requestObject = ConsentAuthorizeUtil.extractRequestObject(consentData.getSpQueryParams());
-            String consentId = ConsentAuthorizeUtil.extractConsentId(requestObject);
-            consentData.setConsentId(consentId);
-            ConsentResource consentResource = consentCoreService.getConsent(consentId, false);
+            String scope = ConsentAuthorizeUtil.extractField(requestObject, FinancialServicesConstants.SCOPE);
 
-            if (!ConsentExtensionConstants.AWAIT_AUTHORISE_STATUS.equals(consentResource.getCurrentStatus())) {
-                log.error("Consent not in authorizable state");
-                //Currently throwing error as 400 response. Developer also have the option of appending a fieldIS_ERROR
-                // to the jsonObject and showing it to the user in the webapp. If so, the IS_ERROR have to bechecked in
-                // any later steps.
-                throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.INVALID_REQUEST,
-                        "Consent not in authorizable state", consentData.getState());
+            if (isPreInitiatedConsent) {
+
+                String consentId = ConsentAuthorizeUtil.extractConsentId(requestObject);
+                consentData.setConsentId(consentId);
+                consentResource = consentCoreService.getConsent(consentId, false);
+
+                if (!ConsentExtensionConstants.AWAIT_AUTHORISE_STATUS.equals(consentResource.getCurrentStatus())) {
+                    log.error("Consent not in authorizable state");
+                    /* Currently throwing error as 400 response. Developer also have the option of appending a field
+                       IS_ERROR to the jsonObject and showing it to the user in the webapp. If so, the IS_ERROR have
+                       to be checked in any later steps. */
+                    throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.INVALID_REQUEST,
+                            "Consent not in authorizable state", consentData.getState());
+                }
+
+                AuthorizationResource authorizationResource = consentCoreService.searchAuthorizations(consentId).get(0);
+                if (!authorizationResource.getAuthorizationStatus().equals(ConsentExtensionConstants.CREATED_STATUS)) {
+                    log.error("Authorisation not in authorizable state");
+                    /* Currently throwing error as 400 response. Developer also have the option of appending a
+                       field IS_ERROR to the jsonObject and showing it to the user in the webapp. If so,
+                       the IS_ERROR have to be checked in any later steps. */
+                    throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.INVALID_REQUEST,
+                            "Authorisation not in authorisable state", consentData.getState());
+                }
+
+                consentData.setAuthResource(authorizationResource);
+                consentDataJSON = ConsentAuthorizeUtil.getConsentDataForPreInitiatedConsent(consentResource);
+            } else {
+                // Create the consent resource using data from request object
+                String consentId = UUID.randomUUID().toString();
+                consentData.setConsentId(consentId);
+                String receipt = ConsentAuthorizeUtil.getReceiptFromRequestObject(requestObject);
+                long defaultValidityPeriod = System.currentTimeMillis() / 1000 + 3600;
+
+                consentResource = new ConsentResource(consentData.getClientId(), receipt,
+                        ConsentExtensionConstants.DEFAULT, ConsentExtensionConstants.CREATED_STATUS);
+                consentResource.setValidityPeriod(defaultValidityPeriod);
+                consentDataJSON = ConsentAuthorizeUtil.getConsentDataForScope(scope);
             }
-
-            AuthorizationResource authorizationResource = consentCoreService.searchAuthorizations(consentId).get(0);
-            if (!authorizationResource.getAuthorizationStatus().equals(ConsentExtensionConstants.CREATED_STATUS)) {
-                log.error("Authorisation not in authorisable state");
-                //Currently throwing error as 400 response. Developer also have the option of appending a fieldIS_ERROR
-                // to the jsonObject and showing it to the user in the webapp. If so, the IS_ERROR have to bechecked in
-                // any later steps.
-                throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.INVALID_REQUEST,
-                        "Authorisation not in authorisable state", consentData.getState());
-            }
-
             consentData.setType(consentResource.getConsentType());
-            consentData.setAuthResource(authorizationResource);
             consentData.setConsentResource(consentResource);
-
-            //Appending Consent Data
-            JSONArray consentDataJSON = ConsentAuthorizeUtil.getConsentData(consentResource);
             jsonObject.put("consentData", consentDataJSON);
 
             //Appending Dummy data for Accounts consent. Ideally should be separate step calling accounts service
@@ -93,16 +120,4 @@ public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
         }
     }
 
-    /**
-     * Get the AuthErrorCode for the given ResponseStatus.
-     * @param responseStatus ResponseStatus
-     * @return AuthErrorCode
-     */
-    private AuthErrorCode getAuthErrorCode(ResponseStatus responseStatus) {
-        if (responseStatus == ResponseStatus.BAD_REQUEST) {
-            return AuthErrorCode.INVALID_REQUEST;
-        } else {
-            return AuthErrorCode.SERVER_ERROR;
-        }
-    }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentRetrievalStep.java
@@ -95,7 +95,7 @@ public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
                 consentData.setAuthResource(authorizationResource);
                 consentDataJSON = ConsentAuthorizeUtil.getConsentDataForPreInitiatedConsent(consentResource);
             } else {
-                // Create the consent resource using data from request object
+                // Create a default type consent resource using data from request object.
                 String consentId = UUID.randomUUID().toString();
                 consentData.setConsentId(consentId);
                 String receipt = ConsentAuthorizeUtil.getReceiptFromRequestObject(requestObject);
@@ -108,11 +108,12 @@ public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
             }
             consentData.setType(consentResource.getConsentType());
             consentData.setConsentResource(consentResource);
-            jsonObject.put("consentData", consentDataJSON);
+            jsonObject.put(ConsentExtensionConstants.CONSENT_DATA, consentDataJSON);
 
-            //Appending Dummy data for Accounts consent. Ideally should be separate step calling accounts service
+            /* Appending Dummy data for Accounts consent. In real-world scenario should be separate step
+             calling accounts service */
             JSONArray accountsJSON = ConsentAuthorizeUtil.appendDummyAccountID();
-            jsonObject.put("accounts", accountsJSON);
+            jsonObject.put(ConsentExtensionConstants.ACCOUNTS, accountsJSON);
 
         } catch (ConsentManagementException e) {
             throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.SERVER_ERROR,

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
@@ -18,6 +18,7 @@
 
 package org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,6 +37,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Base64;
+import java.util.Locale;
 
 /**
  * Util class for consent authorize operations.
@@ -212,7 +214,10 @@ public class ConsentAuthorizeUtil {
         if (scope != null && !scope.trim().isEmpty()) {
             String[] scopeItems = scope.trim().split("\\s+");
             for (String item : scopeItems) {
-                permissions.put(item);
+                // Skip openid scope since it is not relevant to the consent.
+                if (!"openid".equals(item)) {
+                    permissions.put(item);
+                }
             }
         }
 
@@ -541,20 +546,24 @@ public class ConsentAuthorizeUtil {
 
     /**
      * Method to create the consent receipt using the request object.
+     *
      * @param requestObject request object
-     * @return
+     * @return Consent receipt
      */
+    @SuppressFBWarnings("IMPROPER_UNICODE")
     public static String getReceiptFromRequestObject(String requestObject) {
 
         // Extract the space-separated scopes from the request
         String scope = extractField(requestObject, FinancialServicesConstants.SCOPE);
 
-        // Convert scope to uppercase JSON array
         JSONArray permissions = new JSONArray();
         if (scope != null && !scope.trim().isEmpty()) {
             String[] scopeItems = scope.trim().split("\\s+");
             for (String item : scopeItems) {
-                permissions.put(item.toUpperCase());
+                // Skip openid scope since it is not relevant to the consent.
+                if (!"openid".equals(item)) {
+                    permissions.put(item.toUpperCase(Locale.ROOT));
+                }
             }
         }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
@@ -215,9 +215,10 @@ public class ConsentAuthorizeUtil {
             String[] scopeItems = scope.trim().split("\\s+");
             for (String item : scopeItems) {
                 // Skip openid scope since it is not relevant to the consent.
-                if (!"openid".equals(item)) {
-                    permissions.put(item);
+                if (ConsentExtensionConstants.OPENID_SCOPE.equals(item)) {
+                   continue;
                 }
+                permissions.put(item);
             }
         }
 
@@ -561,9 +562,10 @@ public class ConsentAuthorizeUtil {
             String[] scopeItems = scope.trim().split("\\s+");
             for (String item : scopeItems) {
                 // Skip openid scope since it is not relevant to the consent.
-                if (!"openid".equals(item)) {
-                    permissions.put(item.toUpperCase(Locale.ROOT));
+                if (ConsentExtensionConstants.OPENID_SCOPE.equals(item)) {
+                    continue;
                 }
+                permissions.put(item.toUpperCase(Locale.ROOT));
             }
         }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
@@ -567,17 +567,17 @@ public class ConsentAuthorizeUtil {
             }
         }
 
-        // Generate expiration timestamp (server time + 1 hour)
+        // Default expiration timestamp (current time + 1 hour)
         OffsetDateTime expirationTime = OffsetDateTime.now(ZoneId.systemDefault()).plusHours(1);
         String expirationDateTime = expirationTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
         // Build the JSON object
-        JSONObject accountData = new JSONObject();
-        accountData.put("permissions", permissions);
-        accountData.put("expirationDateTime", expirationDateTime);
+        JSONObject receiptData = new JSONObject();
+        receiptData.put(ConsentExtensionConstants.PERMISSIONS, permissions);
+        receiptData.put(ConsentExtensionConstants.EXPIRATION_DATE, expirationDateTime);
 
         JSONObject receipt = new JSONObject();
-        receipt.put("accountData", accountData);
+        receipt.put(ConsentExtensionConstants.DATA, receiptData);
 
         return receipt.toString();
     }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
@@ -31,6 +32,8 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.Res
 
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Base64;
 
@@ -155,7 +158,8 @@ public class ConsentAuthorizeUtil {
      *                        from database.
      * @return ConsentDataJson array
      */
-    public static JSONArray getConsentData(ConsentResource consentResource) throws ConsentException {
+    public static JSONArray getConsentDataForPreInitiatedConsent(ConsentResource consentResource)
+            throws ConsentException {
 
         JSONArray consentDataJSON = new JSONArray();
         try {
@@ -188,6 +192,37 @@ public class ConsentAuthorizeUtil {
         } catch (JSONException e) {
             log.error("Payload is not in JSON Format", e);
             throw new ConsentException(ResponseStatus.BAD_REQUEST, "Payload is not in JSON Format");
+        }
+        return consentDataJSON;
+    }
+
+    /**
+     * Returns consent data to be displayed based on the requested scopes.
+     *
+     * @param scope Scopes given in the request
+     * @return ConsentDataJson array
+     */
+    public static JSONArray getConsentDataForScope(String scope)
+            throws ConsentException {
+
+        JSONArray consentDataJSON = new JSONArray();
+        JSONArray permissions = new JSONArray();
+
+        // Convert space-separated scopes into JSON array
+        if (scope != null && !scope.trim().isEmpty()) {
+            String[] scopeItems = scope.trim().split("\\s+");
+            for (String item : scopeItems) {
+                permissions.put(item);
+            }
+        }
+
+        if (!permissions.isEmpty()) {
+            JSONObject jsonElementPermissions = new JSONObject();
+            jsonElementPermissions.put(ConsentExtensionConstants.TITLE,
+                    ConsentExtensionConstants.PERMISSIONS);
+            jsonElementPermissions.put(StringUtils.lowerCase(ConsentExtensionConstants.DATA),
+                    permissions);
+            consentDataJSON.put(jsonElementPermissions);
         }
         return consentDataJSON;
     }
@@ -502,5 +537,39 @@ public class ConsentAuthorizeUtil {
             throw new ConsentException(ResponseStatus.BAD_REQUEST,
                     ConsentAuthorizeConstants.ACC_CONSENT_RETRIEVAL_ERROR);
         }
+    }
+
+    /**
+     * Method to create the consent receipt using the request object.
+     * @param requestObject request object
+     * @return
+     */
+    public static String getReceiptFromRequestObject(String requestObject) {
+
+        // Extract the space-separated scopes from the request
+        String scope = extractField(requestObject, FinancialServicesConstants.SCOPE);
+
+        // Convert scope to uppercase JSON array
+        JSONArray permissions = new JSONArray();
+        if (scope != null && !scope.trim().isEmpty()) {
+            String[] scopeItems = scope.trim().split("\\s+");
+            for (String item : scopeItems) {
+                permissions.put(item.toUpperCase());
+            }
+        }
+
+        // Generate expiration timestamp (server time + 1 hour)
+        OffsetDateTime expirationTime = OffsetDateTime.now(ZoneId.systemDefault()).plusHours(1);
+        String expirationDateTime = expirationTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        // Build the JSON object
+        JSONObject accountData = new JSONObject();
+        accountData.put("permissions", permissions);
+        accountData.put("expirationDateTime", expirationDateTime);
+
+        JSONObject receipt = new JSONObject();
+        receipt.put("accountData", accountData);
+
+        return receipt.toString();
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
@@ -179,6 +179,7 @@ public class ConsentExtensionConstants {
     public static final int STATUS_FOUND = 302;
     public static final String APPROVAL = "approval";
     public static final String COOKIES = "cookies";
+    public static final String OPENID_SCOPE = "openid";
 
     // Consent Validate Constants
     public static final String HEADERS = "headers";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
@@ -41,7 +41,7 @@ public class ConsentExtensionConstants {
     public static final String AUTHORIZED_STATUS = "Authorised";
     public static final String REVOKED_STATUS = "Revoked";
     public static final String REJECTED_STATUS = "Rejected";
-    public static final String CREATED_STATUS = "created";
+    public static final String CREATED_STATUS = "Created";
     public static final String DEFAULT_AUTH_TYPE = "authorisation";
     public static final String PERMISSIONS = "Permissions";
     public static final String EXPIRATION_DATE = "ExpirationDateTime";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/DefaultConsentPersistStepTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/DefaultConsentPersistStepTest.java
@@ -21,9 +21,11 @@ package org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize
 import org.json.JSONObject;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.impl.DefaultConsentPersistStep;
@@ -58,10 +60,17 @@ public class DefaultConsentPersistStepTest {
     private static ConsentResource consentResourceMock;
     @Mock
     ConsentCoreServiceImpl consentCoreServiceMock;
+
+    private static MockedStatic<FinancialServicesConfigParser> configParser;
     private MockedStatic<ConsentExtensionsDataHolder> consentExtensionsDataHolder;
 
     @BeforeClass
     public void initTest() throws ConsentManagementException {
+
+        configParser = Mockito.mockStatic(FinancialServicesConfigParser.class);
+        FinancialServicesConfigParser configParserMock = Mockito.mock(FinancialServicesConfigParser.class);
+        Mockito.doReturn(true).when(configParserMock).isPreInitiatedConsent();
+        configParser.when(FinancialServicesConfigParser::getInstance).thenReturn(configParserMock);
 
         consentPersistStep = new DefaultConsentPersistStep();
         consentPersistDataMock = mock(ConsentPersistData.class);
@@ -84,6 +93,7 @@ public class DefaultConsentPersistStepTest {
     public void tearDown() {
         // Closing the mockStatic after each test
         consentExtensionsDataHolder.close();
+        configParser.close();
     }
 
     @Test(priority = 1, expectedExceptions = ConsentException.class)

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/DefaultConsentRetrievalStepTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/DefaultConsentRetrievalStepTest.java
@@ -21,9 +21,11 @@ package org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize
 import org.json.JSONObject;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.AuthorizationResource;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentFile;
@@ -57,11 +59,18 @@ public class DefaultConsentRetrievalStepTest {
     ConsentFile consentFileMock;
     @Mock
     ConsentCoreServiceImpl consentCoreServiceMock;
+
     ArrayList<AuthorizationResource> authResources;
+    private static MockedStatic<FinancialServicesConfigParser> configParser;
     private MockedStatic<ConsentExtensionsDataHolder> consentExtensionsDataHolder;
 
     @BeforeClass
     public void initClass() throws ConsentManagementException {
+
+        configParser = Mockito.mockStatic(FinancialServicesConfigParser.class);
+        FinancialServicesConfigParser configParserMock = Mockito.mock(FinancialServicesConfigParser.class);
+        Mockito.doReturn(true).when(configParserMock).isPreInitiatedConsent();
+        configParser.when(FinancialServicesConfigParser::getInstance).thenReturn(configParserMock);
 
         consentRetrievalStep = new DefaultConsentRetrievalStep();
         consentDataMock = mock(ConsentData.class);
@@ -87,6 +96,7 @@ public class DefaultConsentRetrievalStepTest {
     public void tearDown() {
         // Closing the mockStatic after each test
         consentExtensionsDataHolder.close();
+        configParser.close();
     }
 
     @Test

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/ExternalAPIConsentRetrievalStepTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/ExternalAPIConsentRetrievalStepTest.java
@@ -107,7 +107,7 @@ public class ExternalAPIConsentRetrievalStepTest {
 
         // AuthorizationResource
         AuthorizationResource authResource = new AuthorizationResource();
-        authResource.setAuthorizationStatus("created");
+        authResource.setAuthorizationStatus("Created");
         ArrayList<AuthorizationResource> authList = new ArrayList<>();
         authList.add(authResource);
         when(consentCoreService.searchAuthorizations(anyString())).thenReturn(authList);
@@ -176,7 +176,7 @@ public class ExternalAPIConsentRetrievalStepTest {
 
         // Mock AuthorizationResource
         AuthorizationResource mockAuthResource = new AuthorizationResource();
-        mockAuthResource.setAuthorizationStatus("created");
+        mockAuthResource.setAuthorizationStatus("Created");
 
         ArrayList<AuthorizationResource> authList = new ArrayList<>();
         authList.add(mockAuthResource);
@@ -229,7 +229,7 @@ public class ExternalAPIConsentRetrievalStepTest {
 
         // Mock searchAuthorizations() to return a valid AuthorizationResource
         AuthorizationResource mockAuthResource = new AuthorizationResource();
-        mockAuthResource.setAuthorizationStatus("created");
+        mockAuthResource.setAuthorizationStatus("Created");
         ArrayList<AuthorizationResource> authList = new ArrayList<>();
         authList.add(mockAuthResource);
         when(consentCoreService.searchAuthorizations(anyString()))

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/util/TestConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/util/TestConstants.java
@@ -45,7 +45,7 @@ public class TestConstants {
     public static final String SAMPLE_AUTH_ID = "88888";
     public static final String SAMPLE_AUTH_TYPE = "authorizationType";
     public static final String SAMPLE_USER_ID = "admin@wso2.com";
-    public static final String SAMPLE_AUTHORIZATION_STATUS = "created";
+    public static final String SAMPLE_AUTHORIZATION_STATUS = "Created";
     public static final String SAMPLE_MAPPING_ID = "sampleMappingId";
     public static final String SAMPLE_MAPPING_ID_2 = "sampleMappingId2";
     public static final String SAMPLE_ACCOUNT_ID = "123456789";
@@ -54,7 +54,7 @@ public class TestConstants {
     public static final String SAMPLE_PERMISSION = "samplePermission";
     public static final String AUTHORISED_STATUS = "Authorised";
     public static final String AWAITING_AUTH_STATUS = "AwaitingAuthorisation";
-    public static final String CREATED_STATUS = "created";
+    public static final String CREATED_STATUS = "Created";
     public static final String ACCOUNTS = "accounts";
     public static final String PAYMENTS = "payments";
     public static final String FUNDS_CONFIRMATIONS = "fundsconfirmations";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.service/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/service/util/ConsentMgtServiceTestData.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.service/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/service/util/ConsentMgtServiceTestData.java
@@ -102,7 +102,7 @@ public class ConsentMgtServiceTestData {
             (List.of("accounts", "payments", "cof"));
 
     public static final ArrayList<String> SAMPLE_CONSENT_STATUSES_LIST = new ArrayList<>
-            (List.of("created", "authorised", "awaitingAuthorization"));
+            (List.of("Created", "Authorised", "AwaitingAuthorization"));
 
     public static final Map<String, ArrayList<String>> SAMPLE_ACCOUNT_IDS_AND_PERMISSIONS_MAP3 = Map.of(
             "mismatching account ID", new ArrayList<> (List.of("permission5", "permission6")));

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/test/java/org/wso2/financial/services/accelerator/event/notifications/service/util/EventNotificationTestUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/test/java/org/wso2/financial/services/accelerator/event/notifications/service/util/EventNotificationTestUtils.java
@@ -250,7 +250,7 @@ public class EventNotificationTestUtils {
         eventSubscription.setSubscriptionId(subscriptionId);
         eventSubscription.setCallbackUrl("test.com");
         eventSubscription.setEventTypes(EventNotificationTestConstants.SAMPLE_NOTIFICATION_EVENT_TYPES);
-        eventSubscription.setStatus("created");
+        eventSubscription.setStatus("Created");
         eventSubscription.setClientId(EventNotificationTestConstants.SAMPLE_CLIENT_ID);
 
         JSONObject requestData = new JSONObject();


### PR DESCRIPTION
## [Accelerator 4] Add default non initiated consent flow 

> This PR adds changes required to demonstrate a non initiated consent authorization flow (eg: CDS consent authorization flow) without configuring any extension.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/484*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
