### PR TITLE
[Accelerator-4] Fix for copying required accelerator artifacts

### DIFF
--- a/financial-services-accelerator/accelerators/fs-apim/pom.xml
+++ b/financial-services-accelerator/accelerators/fs-apim/pom.xml
@@ -82,14 +82,14 @@
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.common/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.common-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.common-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.gateway/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.gateway-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.gateway-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <unzip src="../../internal-webapps/org.wso2.financial.services.accelerator.demo.backend/target/api#fs#backend.war"

--- a/financial-services-accelerator/accelerators/fs-is/pom.xml
+++ b/financial-services-accelerator/accelerators/fs-is/pom.xml
@@ -87,42 +87,42 @@
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.identity.extensions/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.identity.extensions-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.identity.extensions-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.common/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.common-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.common-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.consent.mgt.service/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.consent.mgt.service-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.consent.mgt.service-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.consent.mgt.extensions/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.consent.mgt.extensions-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.consent.mgt.extensions-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.consent.mgt.dao/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.consent.mgt.dao-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.consent.mgt.dao-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.financial.services.accelerator.event.notifications.service/target">
                                         <filename
-                                                regex="org.wso2.financial.services.accelerator.event.notifications.service-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?\.jar"/>
+                                                regex="org.wso2.financial.services.accelerator.event.notifications.service-\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)*(?&lt;!-javadoc)\.jar"/>
                                     </fileset>
                                 </copy>
 


### PR DESCRIPTION
## [Accelerator-4] Fix for copying required accelerator artifacts

> This PR copies the accelerator artifacts to the accelerator product since previously there was a file name mismatch. The fix avoids copying the jar names that end with "javadoc"

**Issue link:** *required*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
