### PR TITLE
[OB4] Change to update consent status on authorize error

### DIFF
--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -8,13 +8,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v3
+  version: v1.0.0-M4
 servers:
   - url: https://virtserver.swaggerhub.com/wso2-f5b/OB4/1.0.0
     description: SwaggerHub API Auto Mocking
 security:
-  - BasicAuth: []
-  - OAuth2: []
+  - BasicAuth: [ ]
+  - OAuth2: [ ]
 tags:
   - name: Client
     description: APIs for dynamically registering/updating client  related extensions

--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -8,13 +8,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v1.0.0-M4
+  version: v3
 servers:
   - url: https://virtserver.swaggerhub.com/wso2-f5b/OB4/1.0.0
     description: SwaggerHub API Auto Mocking
 security:
-  - BasicAuth: [ ]
-  - OAuth2: [ ]
+  - BasicAuth: []
+  - OAuth2: []
 tags:
   - name: Client
     description: APIs for dynamically registering/updating client  related extensions
@@ -1341,20 +1341,25 @@ components:
           type: object
           description: :"Custom error object to response back"
     FailedResponseInConsentAuthorize:
-      required:
-        - status
-        - errorMessage
-        - newConsentStatus
       type: object
       properties:
+        responseId:
+          type: string
         status:
           type: string
           description: "Indicates the outcome of the request. For a failed operation, this should be set to ERROR."
           enum:
             - ERROR
+        data:
+          $ref: '#/components/schemas/FailedResponseInConsentAuthorizeData'
+    FailedResponseInConsentAuthorizeData:
+      required:
+        - errorMessage
+      type: object
+      properties:
         errorMessage:
           type: string
-          description: "Error messaage to be displayed in the URL"
+          description: "Error message to be displayed in the URL"
         newConsentStatus:
           type: string
           description: "New consent status to be set to the consent"

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
@@ -19,6 +19,7 @@
 package org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.impl;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
@@ -149,6 +150,17 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
             throw new ConsentManagementException(e.getMessage());
         }
         if (externalServiceResponse.getStatus().equals(StatusEnum.ERROR)) {
+            String newConsentStatus = externalServiceResponse.getData().path(
+                    ConsentExtensionConstants.NEW_CONSENT_STATUS).asText();
+            if (StringUtils.isNotBlank(newConsentStatus)) {
+                String consentId = requestDTO.getConsentId();
+                consentCoreService.updateConsentStatus(consentId, newConsentStatus);
+                if (log.isDebugEnabled()) {
+                    log.debug("Status of the consent with id" + consentId.replaceAll("\n\r", "") +
+                            "updated to " + newConsentStatus.replaceAll("\n\r", "") +
+                            "according to the error response set by the api extension.");
+                }
+            }
             throw new FinancialServicesException(externalServiceResponse.getData()
                     .path(FinancialServicesConstants.ERROR_MESSAGE)
                     .asText(FinancialServicesConstants.DEFAULT_ERROR_MESSAGE));

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
@@ -18,6 +18,7 @@
 package org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.impl;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
@@ -41,6 +42,7 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.util.ConsentAuthorizeUtil;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.AuthErrorCode;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.model.ExternalAPIConsentResourceRequestDTO;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.internal.ConsentExtensionsDataHolder;
 import org.wso2.financial.services.accelerator.consent.mgt.service.ConsentCoreService;
@@ -146,6 +148,17 @@ public class ExternalAPIConsentRetrievalStep implements ConsentRetrievalStep {
         ExternalServiceResponse externalServiceResponse = ServiceExtensionUtils.invokeExternalServiceCall(
                 externalServiceRequest, ServiceExtensionTypeEnum.POPULATE_CONSENT_AUTHORIZE_SCREEN);
         if (externalServiceResponse.getStatus().equals(StatusEnum.ERROR)) {
+            String newConsentStatus = externalServiceResponse.getData().path(
+                    ConsentExtensionConstants.NEW_CONSENT_STATUS).asText();
+            if (StringUtils.isNotBlank(newConsentStatus)) {
+                String consentId = requestDTO.getConsentId();
+                consentCoreService.updateConsentStatus(consentId, newConsentStatus);
+                if (log.isDebugEnabled()) {
+                    log.debug("Status of the consent with id" + consentId.replaceAll("\n\r", "") +
+                            "updated to " + newConsentStatus.replaceAll("\n\r", "") +
+                            "according to the error response set by the api extension.");
+                }
+            }
             throw new FinancialServicesException(externalServiceResponse.getData()
                     .path(FinancialServicesConstants.ERROR_MESSAGE)
                     .asText(FinancialServicesConstants.DEFAULT_ERROR_MESSAGE));

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
@@ -6,7 +6,7 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -109,6 +109,7 @@ public class ConsentExtensionConstants {
     public static final String CONSENT_IDS = "consentIds";
     public static final String CLIENT_IDS = "clientIds";
     public static final String CONSENT_TYPES = "consentTypes";
+    public static final String NEW_CONSENT_STATUS = "newConsentStatus";
     public static final String CONSENT_STATUSES = "consentStatuses";
     public static final String USER_IDS = "userIds";
     public static final String FROM_TIME = "fromTime";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ExternalAPIConsentManageUtilsTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ExternalAPIConsentManageUtilsTest.java
@@ -36,8 +36,11 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.mod
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIConsentRevokeResponseDTO;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIModifiedResponseDTO;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIPostConsentGenerateRequestDTO;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIPostFileUploadRequestDTO;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIPreConsentGenerateRequestDTO;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIPreConsentGenerateResponseDTO;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIPreFileUploadRequestDTO;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.model.ExternalAPIPreFileUploadResponseDTO;
 
 import java.util.Map;
 
@@ -175,4 +178,58 @@ public class ExternalAPIConsentManageUtilsTest {
         JsonElement json = result.getModifiedResponse();
         assertEquals(json.getAsJsonObject().get("status").getAsString(), "RETRIEVED");
     }
+
+    @Test
+    public void testCallExternalService_preFileUpload_mocked() throws Exception {
+        ExternalAPIPreFileUploadRequestDTO requestDTO = mock(ExternalAPIPreFileUploadRequestDTO.class);
+        when(requestDTO.toJson()).thenReturn(new JSONObject().put("dummyKey", "dummyValue"));
+
+        ExternalServiceResponse response = new ExternalServiceResponse();
+        response.setStatus(StatusEnum.SUCCESS);
+        staticMock.when(() ->
+                        ServiceExtensionUtils.invokeExternalServiceCall(any(ExternalServiceRequest.class),
+                                eq(ServiceExtensionTypeEnum.PRE_PROCESS_CONSENT_FILE_UPLOAD)))
+                .thenReturn(response);
+
+        ExternalAPIPreFileUploadResponseDTO result =
+                ExternalAPIConsentManageUtils.callExternalService(requestDTO);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testCallExternalService_postFileUpload_mocked() throws Exception {
+        ExternalAPIPostFileUploadRequestDTO requestDTO = mock(ExternalAPIPostFileUploadRequestDTO.class);
+
+        ExternalServiceResponse response = new ExternalServiceResponse();
+        response.setStatus(StatusEnum.SUCCESS);
+        staticMock.when(() ->
+                        ServiceExtensionUtils.invokeExternalServiceCall(any(ExternalServiceRequest.class),
+                                eq(ServiceExtensionTypeEnum.ENRICH_CONSENT_FILE_RESPONSE)))
+                .thenReturn(response);
+
+        ExternalAPIModifiedResponseDTO result =
+                ExternalAPIConsentManageUtils.callExternalService(requestDTO);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testCallExternalService_fileRetrieval_mocked() throws Exception {
+        ExternalAPIConsentRetrieveRequestDTO requestDTO = mock(ExternalAPIConsentRetrieveRequestDTO.class);
+        when(requestDTO.toJson()).thenReturn(new JSONObject().put("dummyKey", "dummyValue"));
+
+        ExternalServiceResponse response = new ExternalServiceResponse();
+        response.setStatus(StatusEnum.SUCCESS);
+        staticMock.when(() ->
+                        ServiceExtensionUtils.invokeExternalServiceCall(any(ExternalServiceRequest.class),
+                                eq(ServiceExtensionTypeEnum.VALIDATE_CONSENT_FILE_RETRIEVAL)))
+                .thenReturn(response);
+
+        ExternalAPIModifiedResponseDTO result =
+                ExternalAPIConsentManageUtils.callExternalServiceForFileRetrieval(requestDTO);
+
+        assertNotNull(result);
+    }
+
 }


### PR DESCRIPTION
## [OB4] Change to update consent status on authorize error

> This PR adds changes required to update consent status on consent authorize error scenarios. The consent status will be updated to the "newConsentStatus" filed sent in the "data" json of the error response.

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
