### PR TITLE
[OB4] Remove authorization resource generate requirement in consent initiation

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
@@ -93,11 +93,6 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
                     throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.SERVER_ERROR,
                             "Consent Id is not available in consent data", consentData.getState());
                 }
-                if (consentData.getAuthResource() == null) {
-                    log.error("Authorization resource is not available in consent data");
-                    throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.SERVER_ERROR,
-                            "Authorization resource is not available in consent data", consentData.getState());
-                }
             } else if (consentData.getConsentId() != null) {
                 consentId = consentData.getConsentId();
                 detailedConsentResource = consentCoreService.getDetailedConsent(consentId);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ExternalAPIUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ExternalAPIUtil.java
@@ -163,6 +163,32 @@ public class ExternalAPIUtil {
                 consentMappingResources, consentID, clientID, receipt, createdTime, updatedTime);
     }
 
+    /**
+     * Constructs a {@link DetailedConsentResource} using {@link ExternalAPIPreConsentPersistResponseDTO}.
+     * <p>
+     *
+     * @param responseConsentResource The consent resource received from the external API pre-consent step.
+     * @return A fully populated {@link DetailedConsentResource}.
+     */
+    public static DetailedConsentResource constructDetailedConsentResource(
+            ExternalAPIConsentResourceResponseDTO responseConsentResource, String clientId) {
+
+        String consentID = UUID.randomUUID().toString();
+        String receipt = new JSONObject(responseConsentResource.getReceipt()).toString();
+        long createdTime = System.currentTimeMillis() / 1000;
+        long updatedTime = System.currentTimeMillis() / 1000;
+
+        List<AuthorizationResource> authorizationResources =
+                buildAuthorizationResources(responseConsentResource.getAuthorizations(), consentID, null,
+                        null, updatedTime);
+
+        List<ConsentMappingResource> consentMappingResources =
+                buildConsentMappingResources(responseConsentResource.getAuthorizations(), authorizationResources);
+
+        return buildDetailedConsentResource(responseConsentResource, authorizationResources,
+                consentMappingResources, consentID, clientId, receipt, createdTime, updatedTime);
+    }
+
 
     /**
      * Builds a list of {@link AuthorizationResource} objects from the ResponseDTO's authorization list.
@@ -252,7 +278,7 @@ public class ExternalAPIUtil {
         String consentID = consentResource.getConsentID();
         String clientID = consentResource.getClientID();
         long createdTime = consentResource.getCreatedTime();
-        long updatedTime = System.currentTimeMillis();
+        long updatedTime = System.currentTimeMillis() / 1000;
 
         String resolvedConsentType = (responseConsentResource.getType() != null) ? responseConsentResource.getType() :
                 consentResource.getConsentType();

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/DefaultConsentManageHandlerTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/DefaultConsentManageHandlerTest.java
@@ -98,6 +98,8 @@ public class DefaultConsentManageHandlerTest {
                 .createAuthorizableConsent(any(), any(), anyString(), anyString(),
                         anyBoolean());
         doReturn(TestUtil.getSampleDetailedConsentResource()).when(consentCoreServiceMock)
+                .storeDetailedConsentResource(any());
+        doReturn(TestUtil.getSampleDetailedConsentResource()).when(consentCoreServiceMock)
                 .getDetailedConsent(anyString());
         doReturn(TestUtil.getSampleConsentResource(TestConstants.AWAITING_AUTH_STATUS)).when(consentCoreServiceMock)
                 .getConsent(anyString(), anyBoolean());


### PR DESCRIPTION
## [OB4] Remove authorization resource generate requirement in consent initiation

> The default accelerator behavior is to create a placeholder for the authorization resource in consent initiation. This PR removes the requirement to create such placeholder. It will be created only if it is sent in the external API response. If not, only the consent resource will be created.

**Issue link:** *required*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
