### PR TITLE
[OB4] Add consent file content to consent authorize extension API request

### DIFF
--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -1737,7 +1737,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StoredAuthorization'
-        consentFileContent:
+        fileContent:
           type: string
     Authorization:
       type: object

--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -1242,8 +1242,6 @@ components:
           description: Custom object with request parameters
         consentResource:
           $ref: '#/components/schemas/StoredDetailedConsentResourceData'
-        consentFileContent:
-          type: string
     ValidateConsentAccessData:
       type: object
       properties:
@@ -1739,6 +1737,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StoredAuthorization'
+        consentFileContent:
+          type: string
     Authorization:
       type: object
       properties:

--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -1242,6 +1242,8 @@ components:
           description: Custom object with request parameters
         consentResource:
           $ref: '#/components/schemas/StoredDetailedConsentResourceData'
+        consentFileContent:
+          type: string
     ValidateConsentAccessData:
       type: object
       properties:

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
@@ -89,13 +89,14 @@ public class ExternalAPIConsentRetrievalStep implements ConsentRetrievalStep {
                     externalAPIConsentResource = new ExternalAPIConsentResourceRequestDTO(detailedConsentResource);
                     try {
                         consentFileContent = consentCoreService.getConsentFile(consentId).getConsentFile();
+                        externalAPIConsentResource.setFileContent(consentFileContent);
                     } catch (ConsentManagementException e) {
                         log.debug("No consent file found for the given consent Id.");
                     }
                 }
             }
             ExternalAPIPreConsentAuthorizeRequestDTO requestDTO = new ExternalAPIPreConsentAuthorizeRequestDTO(
-                    consentData, externalAPIConsentResource, requestParameters, consentFileContent);
+                    consentData, externalAPIConsentResource, requestParameters);
 
             log.debug("Calling external service to get data to be displayed");
             ExternalAPIPreConsentAuthorizeResponseDTO responseDTO = callExternalService(requestDTO);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
@@ -82,14 +82,20 @@ public class ExternalAPIConsentRetrievalStep implements ConsentRetrievalStep {
             }
 
             ExternalAPIConsentResourceRequestDTO externalAPIConsentResource = null;
+            String consentFileContent = "";
             if (consentId != null) {
                 DetailedConsentResource detailedConsentResource = consentCoreService.getDetailedConsent(consentId);
                 if (detailedConsentResource != null) {
                     externalAPIConsentResource = new ExternalAPIConsentResourceRequestDTO(detailedConsentResource);
+                    try {
+                        consentFileContent = consentCoreService.getConsentFile(consentId).getConsentFile();
+                    } catch (ConsentManagementException e) {
+                        log.debug("No consent file found for the given consent Id.");
+                    }
                 }
             }
             ExternalAPIPreConsentAuthorizeRequestDTO requestDTO = new ExternalAPIPreConsentAuthorizeRequestDTO(
-                    consentData, externalAPIConsentResource, requestParameters);
+                    consentData, externalAPIConsentResource, requestParameters, consentFileContent);
 
             log.debug("Calling external service to get data to be displayed");
             ExternalAPIPreConsentAuthorizeResponseDTO responseDTO = callExternalService(requestDTO);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
@@ -91,7 +91,8 @@ public class ExternalAPIConsentRetrievalStep implements ConsentRetrievalStep {
                         consentFileContent = consentCoreService.getConsentFile(consentId).getConsentFile();
                         externalAPIConsentResource.setFileContent(consentFileContent);
                     } catch (ConsentManagementException e) {
-                        log.debug("No consent file found for the given consent Id.");
+                        log.debug("No consent file found for the given consent Id: " +
+                                consentId.replaceAll("\n\r", ""));
                     }
                 }
             }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentAuthorizeRequestDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentAuthorizeRequestDTO.java
@@ -29,17 +29,15 @@ public class ExternalAPIPreConsentAuthorizeRequestDTO {
     private String userId;
     private JSONObject requestParameters;
     private ExternalAPIConsentResourceRequestDTO consentResource;
-    private String consentFileContent;
 
     public ExternalAPIPreConsentAuthorizeRequestDTO(ConsentData consentData,
                                                     ExternalAPIConsentResourceRequestDTO consentResource,
-                                                    JSONObject requestParameters, String consentFileContent) {
+                                                    JSONObject requestParameters) {
 
         this.consentId = consentData.getConsentId();
         this.userId = consentData.getUserId();
         this.consentResource = consentResource;
         this.requestParameters = requestParameters;
-        this.consentFileContent = consentFileContent;
     }
 
     public String getConsentId() {
@@ -73,14 +71,6 @@ public class ExternalAPIPreConsentAuthorizeRequestDTO {
     public void setConsentResource(
             ExternalAPIConsentResourceRequestDTO consentResource) {
         this.consentResource = consentResource;
-    }
-
-    public String getConsentFileContent() {
-        return consentFileContent;
-    }
-
-    public void setConsentFileContent(String consentFileContent) {
-        this.consentFileContent = consentFileContent;
     }
 
     /**

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentAuthorizeRequestDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentAuthorizeRequestDTO.java
@@ -29,15 +29,17 @@ public class ExternalAPIPreConsentAuthorizeRequestDTO {
     private String userId;
     private JSONObject requestParameters;
     private ExternalAPIConsentResourceRequestDTO consentResource;
+    private String consentFileContent;
 
     public ExternalAPIPreConsentAuthorizeRequestDTO(ConsentData consentData,
                                                     ExternalAPIConsentResourceRequestDTO consentResource,
-                                                    JSONObject requestParameters) {
+                                                    JSONObject requestParameters, String consentFileContent) {
 
         this.consentId = consentData.getConsentId();
         this.userId = consentData.getUserId();
         this.consentResource = consentResource;
         this.requestParameters = requestParameters;
+        this.consentFileContent = consentFileContent;
     }
 
     public String getConsentId() {
@@ -71,6 +73,14 @@ public class ExternalAPIPreConsentAuthorizeRequestDTO {
     public void setConsentResource(
             ExternalAPIConsentResourceRequestDTO consentResource) {
         this.consentResource = consentResource;
+    }
+
+    public String getConsentFileContent() {
+        return consentFileContent;
+    }
+
+    public void setConsentFileContent(String consentFileContent) {
+        this.consentFileContent = consentFileContent;
     }
 
     /**

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/model/ExternalAPIConsentResourceRequestDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/model/ExternalAPIConsentResourceRequestDTO.java
@@ -46,6 +46,7 @@ public class ExternalAPIConsentResourceRequestDTO {
     private Map<String, Object> receipt;
     private Map<String, String> attributes;
     private List<Authorization> authorizations;
+    private String fileContent;
 
     public ExternalAPIConsentResourceRequestDTO(ConsentResource consentResource) {
 
@@ -224,6 +225,14 @@ public class ExternalAPIConsentResourceRequestDTO {
     public void setAuthorizations(
             List<Authorization> authorizations) {
         this.authorizations = authorizations;
+    }
+
+    public String getFileContent() {
+        return fileContent;
+    }
+
+    public void setFileContent(String fileContent) {
+        this.fileContent = fileContent;
     }
 
     /**


### PR DESCRIPTION
## [OB4] Add consent file content to consent authorize extension API request

> This PR adds a change to send the consent file in the /populate-consent-authorize-screen extension request if a file is available.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/560*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
