### PR TITLE
[OB4] Persist commonAuthId in default consent persist step

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
@@ -116,13 +116,12 @@ public class DefaultConsentPersistStep implements ConsentPersistStep {
 
         // Create the consent if it is not pre initiated.
         if (isPreInitiatedConsent) {
-           authorizationId = consentData.getAuthResource().getAuthorizationID();
+            authorizationId = consentData.getAuthResource().getAuthorizationID();
         } else {
             DetailedConsentResource createdConsent = consentCoreService.createAuthorizableConsent(
                     consentResource, userId, authStatus, ConsentExtensionConstants.DEFAULT_AUTH_TYPE, true);
             String consentId = createdConsent.getConsentID();
-            authorizationId = consentCoreService.searchAuthorizations(
-                    consentId).get(0).getAuthorizationID();
+            authorizationId = consentCoreService.searchAuthorizations(consentId).get(0).getAuthorizationID();
             // Getting commonAuthId to add as a consent attribute. This is to find the consent in later stages.
             if (consentPersistData.getBrowserCookies() != null) {
                 String commonAuthId = consentPersistData.getBrowserCookies().get(


### PR DESCRIPTION
## [OB4] Persist commonAuthId in default consent persist step

> This PR adds changes to persist commonAuthId in default consent persist step for non initiated consents (similar to CDS authorization flow). This is done to find the consent later in the authorization flow.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/484*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
