### PR TITLE
[OB4] Add request parameters to consent persist extension

### DIFF
--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -1602,13 +1602,23 @@ components:
       properties:
         consentId:
           type: string
+        type:
+          type: string
         isApproved:
           type: boolean
         userGrantedData:
-          type: object
-          description: "Input data from end user"
+          $ref: '#/components/schemas/UserGrantedData'
         consentResource:
           $ref: '#/components/schemas/StoredDetailedConsentResourceData'
+      UserGrantedData:
+        type: object
+        properties:
+          requestParameters:
+            type: object
+          authorizedResources:
+            type: object
+          userId:
+            type: string
     Response200ForPersistAuthorizedConsent:
       oneOf:
         - $ref: '#/components/schemas/SuccessResponsePersistAuthorizedConsent'

--- a/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
+++ b/financial-services-accelerator/accelerators/fs-is/repository/resources/apis/accelerator-extensions-v1.yaml
@@ -1602,23 +1602,21 @@ components:
       properties:
         consentId:
           type: string
-        type:
-          type: string
         isApproved:
           type: boolean
         userGrantedData:
           $ref: '#/components/schemas/UserGrantedData'
         consentResource:
           $ref: '#/components/schemas/StoredDetailedConsentResourceData'
-      UserGrantedData:
-        type: object
-        properties:
-          requestParameters:
-            type: object
-          authorizedResources:
-            type: object
-          userId:
-            type: string
+    UserGrantedData:
+      type: object
+      properties:
+        requestParameters:
+          type: object
+        authorizedResources:
+          type: object
+        userId:
+          type: string
     Response200ForPersistAuthorizedConsent:
       oneOf:
         - $ref: '#/components/schemas/SuccessResponsePersistAuthorizedConsent'

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
@@ -69,7 +69,7 @@ public class DefaultConsentPersistStep implements ConsentPersistStep {
                         "Consent data is not available");
             }
 
-            if (consentData.getConsentId() == null) {
+            if (isPreInitiatedConsent && consentData.getConsentId() == null) {
                 log.error("Consent ID not available in consent data");
                 throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.SERVER_ERROR,
                         "Consent ID not available in consent data", consentData.getState());

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentRetrievalStep.java
@@ -37,8 +37,6 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.Res
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.internal.ConsentExtensionsDataHolder;
 import org.wso2.financial.services.accelerator.consent.mgt.service.ConsentCoreService;
 
-import java.util.UUID;
-
 /**
  * Consent retrieval step default implementation.
  */
@@ -61,6 +59,7 @@ public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
         }
         ConsentCoreService consentCoreService = ConsentExtensionsDataHolder.getInstance().getConsentCoreService();
         String requestObject = ConsentAuthorizeUtil.extractRequestObject(consentData.getSpQueryParams());
+        JSONObject requestParameters = ConsentAuthorizeUtil.getRequestObjectJson(requestObject);
         String scope = ConsentAuthorizeUtil.extractField(requestObject, FinancialServicesConstants.SCOPE);
         JSONArray consentDataJSON;
         ConsentResource consentResource;
@@ -100,8 +99,6 @@ public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
                 consentDataJSON = ConsentAuthorizeUtil.getConsentDataForPreInitiatedConsent(consentResource);
             } else {
                 // Create a default type consent resource using data from request object.
-                String consentId = UUID.randomUUID().toString();
-                consentData.setConsentId(consentId);
                 String receipt = ConsentAuthorizeUtil.getReceiptFromRequestObject(requestObject);
                 long defaultValidityPeriod = System.currentTimeMillis() / 1000 + 3600;
 
@@ -118,6 +115,9 @@ public class DefaultConsentRetrievalStep implements ConsentRetrievalStep {
              calling accounts service */
             JSONArray accountsJSON = ConsentAuthorizeUtil.appendDummyAccountID();
             jsonObject.put(ConsentExtensionConstants.ACCOUNTS, accountsJSON);
+
+            // Set request parameters as metadata to be used in persistence extension
+            consentData.addData(ConsentExtensionConstants.REQUEST_PARAMETERS, requestParameters);
 
         } catch (ConsentManagementException e) {
             throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.SERVER_ERROR,

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
@@ -118,7 +118,6 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
             } else {
                 consentId = UUID.randomUUID().toString();
                 consentData.setConsentId(consentId);
-                consentData.setType(ConsentExtensionConstants.DEFAULT);
 
                 // Getting commonAuthId to add as a consent attribute. This is to find the consent in later stages.
                 if (consentPersistData.getBrowserCookies() != null) {
@@ -133,8 +132,7 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
                     requestParameters, consentData.getUserId());
 
             ExternalAPIPreConsentPersistRequestDTO requestDTO = new ExternalAPIPreConsentPersistRequestDTO(
-                    consentId, consentData.getType(), externalAPIConsentResource, userGrantedData,
-                    consentPersistData.getApproval());
+                    consentId, externalAPIConsentResource, userGrantedData, consentPersistData.getApproval());
             ExternalAPIPreConsentPersistResponseDTO responseDTO = callExternalService(requestDTO);
             ExternalAPIConsentResourceResponseDTO responseConsentResource = responseDTO.getConsentResource();
             persistConsent(responseConsentResource, consentData);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
@@ -52,7 +52,6 @@ import org.wso2.financial.services.accelerator.consent.mgt.service.ConsentCoreSe
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -78,6 +77,25 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
         String consentId;
         DetailedConsentResource detailedConsentResource = null;
         ExternalAPIConsentResourceRequestDTO externalAPIConsentResource = null;
+
+        // Get request object parameters
+        JSONObject requestParameters = new JSONObject();
+        if (consentPersistData.getConsentData() != null && consentPersistData.getConsentData().getMetaDataMap() != null
+                && consentPersistData.getConsentData().getMetaDataMap()
+                .get(ConsentExtensionConstants.REQUEST_PARAMETERS) != null) {
+
+            requestParameters = (JSONObject) consentPersistData.getConsentData().getMetaDataMap()
+                    .get(ConsentExtensionConstants.REQUEST_PARAMETERS);
+            consentPersistData.getConsentData().getMetaDataMap().remove(ConsentExtensionConstants.REQUEST_PARAMETERS);
+        }
+
+        // If there are no request object parameters, add the scope sent as a query parameter.
+        if (requestParameters.isEmpty() && consentPersistData.getConsentData() != null &&
+                consentPersistData.getConsentData().getScopeString() != null) {
+            requestParameters.put(FinancialServicesConstants.SCOPE,
+                    consentPersistData.getConsentData().getScopeString());
+        }
+
         try {
             if (consentData == null) {
                 log.error("Consent data is not available");
@@ -110,12 +128,13 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
                 }
             }
             // Call external service
-            Map<String, Object> consumerInputData = consentPersistData.getMetadata();
-            consumerInputData.put(ConsentExtensionConstants.PERSIST_PAYLOAD, consentPersistData.getPayload());
-            consumerInputData.put(ConsentExtensionConstants.USER_ID, consentData.getUserId());
+            ExternalAPIPreConsentPersistRequestDTO.UserGrantedDataDTO userGrantedData = new
+                    ExternalAPIPreConsentPersistRequestDTO.UserGrantedDataDTO(consentPersistData.getPayload(),
+                    requestParameters, consentData.getUserId());
 
             ExternalAPIPreConsentPersistRequestDTO requestDTO = new ExternalAPIPreConsentPersistRequestDTO(
-                    consentId, externalAPIConsentResource, consumerInputData, consentPersistData.getApproval());
+                    consentId, consentData.getType(), externalAPIConsentResource, userGrantedData,
+                    consentPersistData.getApproval());
             ExternalAPIPreConsentPersistResponseDTO responseDTO = callExternalService(requestDTO);
             ExternalAPIConsentResourceResponseDTO responseConsentResource = responseDTO.getConsentResource();
             persistConsent(responseConsentResource, consentData);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
@@ -107,6 +107,9 @@ public class ExternalAPIConsentRetrievalStep implements ConsentRetrievalStep {
             // Set data to json object to be displayed in consent page.
             jsonObject.put("consentData", consentDataJsonArray);
             jsonObject.put("accounts", consumerDataJsonArray);
+
+            // Set request parameters as metadata to be used in persistence extension
+            consentData.addData(ConsentExtensionConstants.REQUEST_PARAMETERS, requestParameters);
         } catch (FinancialServicesException e) {
             // ToDo: Improve error handling
             throw new ConsentException(consentData.getRedirectURI(), AuthErrorCode.SERVER_ERROR,

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentPersistRequestDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentPersistRequestDTO.java
@@ -17,8 +17,10 @@
  */
 package org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.model;
 
+import org.json.JSONObject;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.model.ExternalAPIConsentResourceRequestDTO;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -27,14 +29,17 @@ import java.util.Map;
 public class ExternalAPIPreConsentPersistRequestDTO {
 
     private String consentId;
+    private String type;
     private ExternalAPIConsentResourceRequestDTO consentResource;
-    private Map<String, Object> userGrantedData;
+    private UserGrantedDataDTO userGrantedData;
     private boolean isApproved;
 
-    public ExternalAPIPreConsentPersistRequestDTO(String consentId,
+    public ExternalAPIPreConsentPersistRequestDTO(String consentId, String type,
                                                   ExternalAPIConsentResourceRequestDTO consentResource,
-                                                  Map<String, Object> userGrantedData, boolean isApproved) {
+                                                  UserGrantedDataDTO userGrantedData,
+                                                  boolean isApproved) {
         this.consentId = consentId;
+        this.type = type;
         this.consentResource = consentResource;
         this.userGrantedData = userGrantedData;
         this.isApproved = isApproved;
@@ -48,20 +53,27 @@ public class ExternalAPIPreConsentPersistRequestDTO {
         this.consentId = consentId;
     }
 
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
     public ExternalAPIConsentResourceRequestDTO getConsentResource() {
         return consentResource;
     }
 
-    public void setConsentResource(
-            ExternalAPIConsentResourceRequestDTO consentResource) {
+    public void setConsentResource(ExternalAPIConsentResourceRequestDTO consentResource) {
         this.consentResource = consentResource;
     }
 
-    public Map<String, Object> getUserGrantedData() {
+    public UserGrantedDataDTO getUserGrantedData() {
         return userGrantedData;
     }
 
-    public void setUserGrantedData(Map<String, Object> userGrantedData) {
+    public void setUserGrantedData(UserGrantedDataDTO userGrantedData) {
         this.userGrantedData = userGrantedData;
     }
 
@@ -71,5 +83,66 @@ public class ExternalAPIPreConsentPersistRequestDTO {
 
     public void setIsApproved(boolean isApproved) {
         this.isApproved = isApproved;
+    }
+
+    /**
+     * Inner DTO class for user granted data.
+     */
+    public static class UserGrantedDataDTO {
+
+        private Map<String, Object> authorizedResources;
+        private JSONObject requestParameters;
+        private String userId;
+
+        public UserGrantedDataDTO() {
+            // Default constructor
+        }
+
+        /**
+         * Constructs the DTO from the persist payload.
+         *
+         * @param persistPayload    JSONObject with consent-related user input
+         * @param requestParameters JSONObject of request parameters
+         * @param userId            User identifier
+         */
+        public UserGrantedDataDTO(JSONObject persistPayload,
+                                  JSONObject requestParameters,
+                                  String userId) {
+
+            this.authorizedResources = new HashMap<>();
+
+            if (persistPayload != null) {
+                for (String key : persistPayload.keySet()) {
+                    this.authorizedResources.put(key, persistPayload.get(key));
+                }
+            }
+
+            this.requestParameters = requestParameters;
+            this.userId = userId;
+        }
+
+        public Map<String, Object> getAuthorizedResources() {
+            return authorizedResources;
+        }
+
+        public void setAuthorizedResources(Map<String, Object> authorizedResources) {
+            this.authorizedResources = authorizedResources;
+        }
+
+        public JSONObject getRequestParameters() {
+            return requestParameters;
+        }
+
+        public void setRequestParameters(JSONObject requestParameters) {
+            this.requestParameters = requestParameters;
+        }
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public void setUserId(String userId) {
+            this.userId = userId;
+        }
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentPersistRequestDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ExternalAPIPreConsentPersistRequestDTO.java
@@ -29,17 +29,14 @@ import java.util.Map;
 public class ExternalAPIPreConsentPersistRequestDTO {
 
     private String consentId;
-    private String type;
     private ExternalAPIConsentResourceRequestDTO consentResource;
     private UserGrantedDataDTO userGrantedData;
     private boolean isApproved;
 
-    public ExternalAPIPreConsentPersistRequestDTO(String consentId, String type,
+    public ExternalAPIPreConsentPersistRequestDTO(String consentId,
                                                   ExternalAPIConsentResourceRequestDTO consentResource,
-                                                  UserGrantedDataDTO userGrantedData,
-                                                  boolean isApproved) {
+                                                  UserGrantedDataDTO userGrantedData, boolean isApproved) {
         this.consentId = consentId;
-        this.type = type;
         this.consentResource = consentResource;
         this.userGrantedData = userGrantedData;
         this.isApproved = isApproved;
@@ -51,14 +48,6 @@ public class ExternalAPIPreConsentPersistRequestDTO {
 
     public void setConsentId(String consentId) {
         this.consentId = consentId;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
     }
 
     public ExternalAPIConsentResourceRequestDTO getConsentResource() {
@@ -95,7 +84,6 @@ public class ExternalAPIPreConsentPersistRequestDTO {
         private String userId;
 
         public UserGrantedDataDTO() {
-            // Default constructor
         }
 
         /**

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentExtensionConstants.java
@@ -163,6 +163,7 @@ public class ConsentExtensionConstants {
     public static final String PERMISSION = "permission";
     public static final String MAPPING_STATUS = "mappingStatus";
     public static final String MAPPING_RESOURCES = "consentMappingResources";
+    public static final String REQUEST_PARAMETERS = "requestParameters";
 
     //Consent Authorize Constants
     public static final String IS_ERROR = "isError";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/ExternalAPIConsentPersistStepTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/ExternalAPIConsentPersistStepTest.java
@@ -232,7 +232,6 @@ public class ExternalAPIConsentPersistStepTest {
             new ExternalAPIConsentPersistStep().execute(persistData);
 
             assert consentData.getConsentId() != null;
-            assertEquals(consentData.getType(), "default");
             assertEquals(consentData.getMetaDataMap().get("commonAuthId"), "auth-cookie-id");
 
             verify(consentCoreService).storeDetailedConsentResource(constructed);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ExternalAPIUtilTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ExternalAPIUtilTest.java
@@ -201,7 +201,7 @@ public class ExternalAPIUtilTest {
 
         // Build the request DTO
         ExternalAPIPreConsentPersistRequestDTO requestDTO = new ExternalAPIPreConsentPersistRequestDTO(
-                consentResource.getConsentID(), consentResource.getConsentType(), consentResourceDTO,
+                consentResource.getConsentID(), consentResourceDTO,
                 new ExternalAPIPreConsentPersistRequestDTO.UserGrantedDataDTO(), true
         );
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ExternalAPIUtilTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ExternalAPIUtilTest.java
@@ -201,10 +201,8 @@ public class ExternalAPIUtilTest {
 
         // Build the request DTO
         ExternalAPIPreConsentPersistRequestDTO requestDTO = new ExternalAPIPreConsentPersistRequestDTO(
-                consentResource.getConsentID(),
-                consentResourceDTO,
-                Map.of("channel", "mobile"),
-                true
+                consentResource.getConsentID(), consentResource.getConsentType(), consentResourceDTO,
+                new ExternalAPIPreConsentPersistRequestDTO.UserGrantedDataDTO(), true
         );
 
         // Create the ExternalServiceRequest
@@ -216,7 +214,6 @@ public class ExternalAPIUtilTest {
 
         assertEquals(payload.getString("consentId"), consentResource.getConsentID());
         assertTrue(payload.toString().contains("AwaitingAuthorisation"));
-        assertTrue(payload.toString().contains("channel"));
         assertTrue(payload.toString().contains("\"isApproved\":true"));
     }
 


### PR DESCRIPTION
## [OB4] Add request parameters to consent persist extension

> This PR contains following changes:
    - Add request object parameters to /persist-authorized-consent extension request
    - If request object parameters are not present, add scope from query parameters
    - Introduce a proper structure to userGrantedData object in /persist-authorized-consent extension request
    - Fix issues occurred when only the /persist-authorized-consent extension is enabled

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
