### PR TITLE
[OB4][Perf] Make objectMapper a class variable

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.common/src/main/java/org/wso2/financial/services/accelerator/common/util/ServiceExtensionUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.common/src/main/java/org/wso2/financial/services/accelerator/common/util/ServiceExtensionUtils.java
@@ -56,6 +56,7 @@ import java.util.List;
 public class ServiceExtensionUtils {
 
     private static final Log log = LogFactory.getLog(ServiceExtensionUtils.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static boolean isInvokeExternalService(ServiceExtensionTypeEnum serviceExtensionTypeEnum) {
 
@@ -187,7 +188,6 @@ public class ServiceExtensionUtils {
      */
     public static <T> T mapResponse(String jsonResponse, Class<T> clazz) throws JsonProcessingException {
 
-        ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.readValue(jsonResponse, clazz);
     }
 


### PR DESCRIPTION
## [OB4][Perf] Make objectMapper a class variable

> This PR adds a fix to make the object mapper variable a class variable. At present an ObjectMapper instace is created per extension api request which hinders performance at high load.

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
