### PR TITLE
[Accelerator 4] Validate session data key to check if it as a valid UUID

### DIFF
--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentConfirmServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentConfirmServlet.java
@@ -43,6 +43,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.Cookie;
@@ -108,8 +109,20 @@ public class FSConsentConfirmServlet extends HttpServlet {
 
         consentData.put(Constants.METADATA, metadata);
 
+        String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY_CONSENT);
+
+        // validating session data key format
+        try {
+            UUID.fromString(sessionDataKey);
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid UUID", e);
+            session.invalidate();
+            response.sendRedirect("retry.do?status=Error&statusMsg=Invalid UUID");
+            return;
+        }
+
         String redirectURL = persistConsentData(
-                consentData, request.getParameter(Constants.SESSION_DATA_KEY_CONSENT), getServletContext());
+                consentData, sessionDataKey, getServletContext());
 
         // Invoke authorize flow
         if (redirectURL != null) {

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentConfirmServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentConfirmServlet.java
@@ -27,7 +27,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.poi.sl.draw.geom.PresetGeometries;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentConfirmServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentConfirmServlet.java
@@ -76,9 +76,9 @@ public class FSConsentConfirmServlet extends HttpServlet {
         try {
             UUID.fromString(sessionDataKey);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid UUID", e);
+            log.error("Invalid session data key", e);
             session.invalidate();
-            response.sendRedirect("retry.do?status=Error&statusMsg=Invalid UUID");
+            response.sendRedirect("retry.do?status=Error&statusMsg=Invalid session data key");
             return;
         }
 

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
@@ -43,6 +43,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.UUID;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -81,6 +82,17 @@ public class FSConsentServlet extends HttpServlet {
 
         // get consent data
         String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY_CONSENT);
+
+        // validating session data key format
+        try {
+            UUID.fromString(sessionDataKey);
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid UUID", e);
+            request.getSession().invalidate();
+            response.sendRedirect("retry.do?status=Error&statusMsg=Invalid UUID");
+            return;
+        }
+
         HttpResponse consentDataResponse = getConsentDataWithKey(sessionDataKey, getServletContext());
         JSONObject dataSet = new JSONObject();
         log.debug("HTTP response for consent retrieval" + consentDataResponse.toString());

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
@@ -87,9 +87,9 @@ public class FSConsentServlet extends HttpServlet {
         try {
             UUID.fromString(sessionDataKey);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid UUID", e);
+            log.error("Invalid session data key", e);
             request.getSession().invalidate();
-            response.sendRedirect("retry.do?status=Error&statusMsg=Invalid UUID");
+            response.sendRedirect("retry.do?status=Error&statusMsg=Invalid session data key");
             return;
         }
 

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
@@ -77,8 +77,8 @@ public class FSConsentServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest originalRequest, HttpServletResponse response)
             throws IOException, ServletException {
+
         HttpServletRequest request = originalRequest;
-        fsAuthServletTK = AuthenticationUtils.getAuthExtension();
 
         // get consent data
         String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY_CONSENT);
@@ -92,6 +92,8 @@ public class FSConsentServlet extends HttpServlet {
             response.sendRedirect("retry.do?status=Error&statusMsg=Invalid UUID");
             return;
         }
+
+        fsAuthServletTK = AuthenticationUtils.getAuthExtension();
 
         HttpResponse consentDataResponse = getConsentDataWithKey(sessionDataKey, getServletContext());
         JSONObject dataSet = new JSONObject();


### PR DESCRIPTION
## [Accelerator 4] Validate session data key to check if it as a valid UUID

> This fixes a possible SSRF attack where the session data key is obtained from outside, it is validated against a UUID format to verify if there are no unexpected input provided by the users

**Issue link:** *required*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
