### PR TITLE
Using regex to find consent ID from resource path

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
@@ -202,9 +202,9 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             }
             consentManageData.setResponseStatus(ResponseStatus.OK);
         } catch (ConsentManagementException | JSONException e) {
-            log.error("Error Occurred while handling the request", e);
+            log.error("Error Occurred while retrieving the consent", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
-                    "Error Occurred while handling the request", ConsentOperationEnum.CONSENT_RETRIEVE);
+                    "Error Occurred while retrieving the consent", ConsentOperationEnum.CONSENT_RETRIEVE);
         }
     }
 
@@ -312,9 +312,9 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             consentManageData.setResponseStatus(ResponseStatus.CREATED);
 
         } catch (ConsentManagementException e) {
-            log.error("Error Occurred while handling the request", e);
+            log.error("Error Occurred while creating the consent", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
-                    "Error Occurred while handling the request", ConsentOperationEnum.CONSENT_CREATE);
+                    "Error Occurred while creating the consent", ConsentOperationEnum.CONSENT_CREATE);
         }
 
     }
@@ -558,7 +558,7 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             }
             consentManageData.setResponseStatus(ResponseStatus.OK);
         } catch (ConsentManagementException e) {
-            log.error("Error Occurred while handling the request", e);
+            log.error("Error Occurred while uploading consent file", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
                     ConsentOperationEnum.CONSENT_FILE_UPLOAD);
         }
@@ -638,9 +638,9 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             consentManageData.setResponsePayload(consentFile.getConsentFile());
             consentManageData.setResponseStatus(ResponseStatus.OK);
         } catch (ConsentManagementException | JSONException e) {
-            log.error("Error Occurred while handling the request", e);
+            log.error("Error Occurred while retrieving consent file", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
-                    "Error Occurred while handling the request", ConsentOperationEnum.CONSENT_FILE_RETRIEVAL);
+                    "Error Occurred while retrieving consent file", ConsentOperationEnum.CONSENT_FILE_RETRIEVAL);
         }
     }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ConsentManageUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ConsentManageUtils.java
@@ -22,7 +22,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionExporter;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentOperationEnum;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ResponseStatus;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.ConsentManageValidator;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.builder.ConsentManageBuilder;
 
@@ -33,6 +36,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Utility class for consent manage module.
@@ -41,6 +45,7 @@ public class ConsentManageUtils {
 
     private static final Log log = LogFactory.getLog(ConsentManageUtils.class);
     private static final FinancialServicesConfigParser parser = FinancialServicesConfigParser.getInstance();
+    private static final Pattern UUID_PATTERN = Pattern.compile(FinancialServicesConstants.UUID_REGEX);
 
     public static boolean isConsentExpirationTimeValid(String expDateVal) {
 
@@ -217,5 +222,29 @@ public class ConsentManageUtils {
 
         ConsentManageBuilder consentManageBuilder = ConsentExtensionExporter.getConsentManageBuilder();
         return consentManageBuilder.getConsentManageValidator();
+    }
+
+    /**
+     * Extract consent id from resource path.
+     *
+     * @param resourcePath      addressed resource path
+     * @param consentOperation  consent operation using this method
+     * @return  consent id
+     * @throws ConsentException if a valid consent id doesn't exist in path
+     */
+    public static String extractConsentIdFromPath(String resourcePath, ConsentOperationEnum consentOperation) {
+        // Retrieve first UUID in request path as consent id
+        if (resourcePath != null && !resourcePath.isEmpty()) {
+            for (String part : resourcePath.split("/")) {
+                if (UUID_PATTERN.matcher(part).matches()) {
+                    return part;
+                }
+            }
+        }
+
+        log.error("Invalid Request Path. Valid consent id not found.");
+        throw new ConsentException(ResponseStatus.BAD_REQUEST,
+                "Invalid Request Path. Valid consent id not found.",
+                consentOperation);
     }
 }


### PR DESCRIPTION
## Using regex to find consent ID from resource path

> This PR uses a regex match to identify the consent id from a request path and uses it for retrieval, revocation, file upload and file retrieval. It extracts the first UUID in the resource path as consent id.

**Issue link:** https://github.com/wso2/financial-services-accelerator/issues/622

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
