### PR TITLE
Set account identification as display name for payments and CoF

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
@@ -495,7 +495,7 @@ public class ConsentAuthorizeUtil {
                     debtorAccount.getString(ConsentExtensionConstants.NAME) != null) {
                 debtorAccountArray.put(ConsentExtensionConstants.NAME_TITLE + " : " +
                         debtorAccount.getString(ConsentExtensionConstants.NAME));
-                initiatedAccount.put(ConsentAuthorizeConstants.DISPLAY_NAME,
+                initiatedAccount.put(ConsentExtensionConstants.NAME,
                         debtorAccount.getString(ConsentExtensionConstants.NAME));
             }
 
@@ -512,7 +512,11 @@ public class ConsentAuthorizeUtil {
             if (debtorAccount.getString(ConsentExtensionConstants.IDENTIFICATION) != null) {
                 debtorAccountArray.put(ConsentExtensionConstants.IDENTIFICATION_TITLE + " : " +
                         debtorAccount.getString(ConsentExtensionConstants.IDENTIFICATION));
-                initiatedAccount.put(ConsentAuthorizeConstants.ACCOUNT_ID,
+                initiatedAccount.put(ConsentExtensionConstants.IDENTIFICATION,
+                        debtorAccount.getString(ConsentExtensionConstants.IDENTIFICATION));
+
+                // Set account identification as account display name
+                initiatedAccount.put(ConsentAuthorizeConstants.DISPLAY_NAME,
                         debtorAccount.getString(ConsentExtensionConstants.IDENTIFICATION));
             }
 


### PR DESCRIPTION
## Set account identification as display name for payments and CoF

> This PR changes the default flow's account display name of payment and CoF consents to the account's identification (in consent authorization).

**Issue link:** *required*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
