### PR TITLE
Fixing issue in handling 400 & 500 responses from service extension

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.common/src/main/java/org/wso2/financial/services/accelerator/common/util/ServiceExtensionUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.common/src/main/java/org/wso2/financial/services/accelerator/common/util/ServiceExtensionUtils.java
@@ -151,6 +151,14 @@ public class ServiceExtensionUtils {
                         log.error(String.format(ErrorConstants.EXTERNAL_SERVICE_DEFAULT_ERROR +
                                         "Status code: %s, Error: %s", statusCode,
                                 responseContent.replaceAll("[\r\n]", "")));
+                        if (statusCode == 400 || statusCode == 500) {
+                            ExternalServiceResponse externalServiceResponse = mapResponse(responseContent,
+                                    ExternalServiceResponse.class);
+
+                            throw new FinancialServicesException(externalServiceResponse.getData()
+                                    .path(FinancialServicesConstants.ERROR_DESCRIPTION)
+                                    .asText(ErrorConstants.EXTERNAL_SERVICE_DEFAULT_ERROR));
+                        }
                         throw new FinancialServicesException(ErrorConstants.EXTERNAL_SERVICE_DEFAULT_ERROR);
                     }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/admin/impl/DefaultConsentAdminHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/admin/impl/DefaultConsentAdminHandler.java
@@ -44,6 +44,7 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.admin.util
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.admin.utils.ExternalAPIConsentAdminUtils;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentOperationEnum;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ResponseStatus;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.model.ExternalAPIConsentResourceRequestDTO;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.internal.ConsentExtensionsDataHolder;
@@ -185,8 +186,8 @@ public class DefaultConsentAdminHandler implements ConsentAdminHandler {
                 enrichedSearchResult.put(ConsentExtensionConstants.METADATA, metadata);
                 consentAdminData.setResponsePayload(enrichedSearchResult);
             } catch (FinancialServicesException e) {
-                throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
-                        "Exception occurred while searching consents", e);
+                throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
+                        ConsentOperationEnum.CONSENT_SEARCH);
             }
         } else {
             JSONObject metadata = new JSONObject();
@@ -238,8 +239,8 @@ public class DefaultConsentAdminHandler implements ConsentAdminHandler {
                                 userId, responseDTO.getRequireTokenRevocation(),
                                 ConsentExtensionConstants.CONSENT_REVOKE_FROM_DASHBOARD_REASON);
                     } catch (FinancialServicesException e) {
-                        throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
-                                "Exception occurred while revoking the consent", e);
+                        throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
+                                ConsentOperationEnum.CONSENT_SEARCH);
                     }
                 } else {
                     if (!ConsentExtensionConstants.AUTHORIZED_STATUS.equals(consentResource.getCurrentStatus())) {
@@ -316,8 +317,8 @@ public class DefaultConsentAdminHandler implements ConsentAdminHandler {
                     count = responseDTO.getEnrichedSearchResult().length();
 
                 } catch (FinancialServicesException e) {
-                    throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
-                            "Exception occurred while searching consents", e);
+                    throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
+                            ConsentOperationEnum.CONSENT_SEARCH);
                 }
             } else {
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
@@ -196,14 +196,9 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
             ExternalAPIPreConsentPersistRequestDTO requestDTO) throws FinancialServicesException {
 
         ExternalServiceRequest externalServiceRequest = ExternalAPIUtil.createExternalServiceRequest(requestDTO);
-        ExternalServiceResponse externalServiceResponse;
-
-        try {
-            externalServiceResponse = ServiceExtensionUtils.invokeExternalServiceCall(
-                    externalServiceRequest, ServiceExtensionTypeEnum.PERSIST_AUTHORIZED_CONSENT);
-        } catch (FinancialServicesException e) {
-            throw new ConsentManagementException(e.getMessage());
-        }
+        log.debug("Invoking external service for consent persistence with service type: PERSIST_AUTHORIZED_CONSENT");
+        ExternalServiceResponse externalServiceResponse = ServiceExtensionUtils.invokeExternalServiceCall(
+                externalServiceRequest, ServiceExtensionTypeEnum.PERSIST_AUTHORIZED_CONSENT);
         if (externalServiceResponse.getStatus().equals(StatusEnum.ERROR)) {
             String newConsentStatus = externalServiceResponse.getData().path(
                     ConsentExtensionConstants.NEW_CONSENT_STATUS).asText();

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/AccountDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/AccountDTO.java
@@ -30,7 +30,7 @@ import javax.validation.constraints.NotEmpty;
  * Account object for external API consent retrieval.
  */
 public class AccountDTO {
-    @NotEmpty
+    @NotEmpty(message = "Display name in Account Object cannot be empty")
     private String displayName;
     private String accountId;
     

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ConsentDataDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/ConsentDataDTO.java
@@ -32,7 +32,7 @@ import javax.validation.constraints.NotEmpty;
  * Consent data object for external API consent retrieval.
  */
 public class ConsentDataDTO {
-    @NotEmpty
+    @NotEmpty(message = "Consent Type in ConsentData Object cannot be empty")
     private String type;
 
     @Valid

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/PermissionDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/model/PermissionDTO.java
@@ -26,9 +26,9 @@ import javax.validation.constraints.NotEmpty;
  * Permissions object for external API consent retrieval.
  */
 public class PermissionDTO {
-    @NotEmpty
+    @NotEmpty(message = "UUID in Permission Object cannot be empty")
     private String uid;
-    @NotEmpty
+    @NotEmpty(message = "Display Values in Permission Object cannot be empty")
     private List<String> displayValues;
     private List<AccountDTO> initiatedAccounts;
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Utils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Utils.java
@@ -336,7 +336,8 @@ public class Utils {
      */
     public static String[] getLanguagePropertiesForLocale(Locale locale) {
         if (log.isDebugEnabled()) {
-            log.debug("Getting language properties for locale: " + locale.toString());
+            log.debug(String.format("Getting language properties for locale: %s",
+                    locale.toString().replaceAll("[\r\n]", "")));
         }
         try (InputStream inputStream = getClassLoaderResourceAsStream("LanguageOptions.properties")) {
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Utils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Utils.java
@@ -335,10 +335,6 @@ public class Utils {
      * @return  fetched language property (with fallback)
      */
     public static String[] getLanguagePropertiesForLocale(Locale locale) {
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Getting language properties for locale: %s",
-                    locale.toString().replaceAll("[\r\n]", "")));
-        }
         try (InputStream inputStream = getClassLoaderResourceAsStream("LanguageOptions.properties")) {
 
             if (inputStream == null) {

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentOperationEnum.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/ConsentOperationEnum.java
@@ -28,6 +28,7 @@ public enum ConsentOperationEnum {
     CONSENT_RETRIEVE("consent_retrieve"),
     CONSENT_DELETE("consent_delete"),
     CONSENT_UPDATE("consent_update"),
+    CONSENT_SEARCH("consent_search"),
     CONSENT_PARTIAL_UPDATE("consent_partial_update"),
     CONSENT_FILE_UPLOAD("consent_file_upload"),
     CONSENT_FILE_RETRIEVAL("consent_file_retrieval");

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/idempotency/IdempotencyValidator.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/common/idempotency/IdempotencyValidator.java
@@ -28,6 +28,7 @@ import org.w3c.dom.Document;
 import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.constant.ErrorConstants;
 import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
+import org.wso2.financial.services.accelerator.common.exception.FinancialServicesException;
 import org.wso2.financial.services.accelerator.common.extension.model.ServiceExtensionTypeEnum;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentFile;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.DetailedConsentResource;
@@ -149,6 +150,10 @@ public class IdempotencyValidator {
             log.error("Error Occurred while handling the request", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
                     "Error Occurred while handling the request", consentOperationEnum);
+        } catch (FinancialServicesException e) {
+            log.error("Error Occurred while handling the request", e);
+            throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
+                    consentOperationEnum);
         }
         return false;
     }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
@@ -25,6 +25,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
+import org.wso2.financial.services.accelerator.common.exception.FinancialServicesException;
 import org.wso2.financial.services.accelerator.common.extension.model.ServiceExtensionTypeEnum;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentFile;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
@@ -190,6 +191,10 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             log.error("Error Occurred while retrieving the consent", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
                     "Error Occurred while retrieving the consent", ConsentOperationEnum.CONSENT_RETRIEVE);
+        } catch (FinancialServicesException e) {
+            log.error("Error Occurred while retrieving the consent", e);
+            throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
+                    e.getMessage(), ConsentOperationEnum.CONSENT_RETRIEVE);
         }
     }
 
@@ -300,6 +305,10 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             log.error("Error Occurred while creating the consent", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
                     "Error Occurred while creating the consent", ConsentOperationEnum.CONSENT_CREATE);
+        } catch (FinancialServicesException e) {
+            log.error("Error Occurred while creating the consent", e);
+            throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
+                    ConsentOperationEnum.CONSENT_CREATE);
         }
 
     }
@@ -400,6 +409,11 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             }
             consentManageData.setResponseStatus(ResponseStatus.NO_CONTENT);
         } catch (ConsentManagementException e) {
+
+            log.error("Error occurred while deleting the consent", e);
+            throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
+                    "Error occurred while deleting the consent", ConsentOperationEnum.CONSENT_DELETE);
+        } catch (FinancialServicesException e) {
             log.error(e.getMessage().replaceAll("[\r\n]+", ""));
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
                     e.getMessage().replaceAll("[\r\n]+", ""), ConsentOperationEnum.CONSENT_DELETE);
@@ -523,6 +537,10 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             consentManageData.setResponseStatus(ResponseStatus.OK);
         } catch (ConsentManagementException e) {
             log.error("Error Occurred while uploading consent file", e);
+            throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
+                    "Error Occurred while uploading consent file", ConsentOperationEnum.CONSENT_FILE_UPLOAD);
+        } catch (FinancialServicesException e) {
+            log.error("Error Occurred while uploading consent file", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
                     ConsentOperationEnum.CONSENT_FILE_UPLOAD);
         }
@@ -595,6 +613,10 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
             log.error("Error Occurred while retrieving consent file", e);
             throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR,
                     "Error Occurred while retrieving consent file", ConsentOperationEnum.CONSENT_FILE_RETRIEVAL);
+        } catch (FinancialServicesException e) {
+            log.error("Error Occurred while retrieving consent file", e);
+            throw new ConsentException(ResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage(),
+                    ConsentOperationEnum.CONSENT_FILE_RETRIEVAL);
         }
     }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ExternalAPIConsentManageUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ExternalAPIConsentManageUtils.java
@@ -18,8 +18,9 @@
 package org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.utils;
 
 import com.google.gson.Gson;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
-import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.common.exception.FinancialServicesException;
 import org.wso2.financial.services.accelerator.common.extension.model.ExternalServiceRequest;
 import org.wso2.financial.services.accelerator.common.extension.model.ExternalServiceResponse;
@@ -46,16 +47,17 @@ import java.util.UUID;
 public class ExternalAPIConsentManageUtils {
 
     private static final Gson gson = new Gson();
+    private static final Log log = LogFactory.getLog(ExternalAPIConsentManageUtils.class);
 
     /**
      * Method to call external service for pre consent generation.
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIPreConsentGenerateResponseDTO callExternalService(
-            ExternalAPIPreConsentGenerateRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIPreConsentGenerateRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = new JSONObject(requestDTO);
         JSONObject responseJson = callExternalService(requestJson,
@@ -68,12 +70,13 @@ public class ExternalAPIConsentManageUtils {
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIModifiedResponseDTO callExternalService(
-            ExternalAPIPostConsentGenerateRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIPostConsentGenerateRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = requestDTO.toJson();
+        log.debug("Calling external service for post consent generation");
         JSONObject responseJson = callExternalService(requestJson,
                 ServiceExtensionTypeEnum.ENRICH_CONSENT_CREATION_RESPONSE);
         return gson.fromJson(responseJson.toString(), ExternalAPIModifiedResponseDTO.class);
@@ -84,12 +87,13 @@ public class ExternalAPIConsentManageUtils {
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIConsentRevokeResponseDTO callExternalService(
-            ExternalAPIConsentRevokeRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIConsentRevokeRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = requestDTO.toJson();
+        log.debug("Calling external service for consent revocation");
         JSONObject responseJson = callExternalService(requestJson,
                 ServiceExtensionTypeEnum.PRE_PROCESS_CONSENT_REVOKE);
         return gson.fromJson(responseJson.toString(), ExternalAPIConsentRevokeResponseDTO.class);
@@ -100,12 +104,13 @@ public class ExternalAPIConsentManageUtils {
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIModifiedResponseDTO callExternalService(
-            ExternalAPIConsentRetrieveRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIConsentRetrieveRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = requestDTO.toJson();
+        log.debug("Calling external service for consent retrieval");
         JSONObject responseJson = callExternalService(requestJson,
                 ServiceExtensionTypeEnum.PRE_PROCESS_CONSENT_RETRIEVAL);
         return gson.fromJson(responseJson.toString(), ExternalAPIModifiedResponseDTO.class);
@@ -116,12 +121,13 @@ public class ExternalAPIConsentManageUtils {
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIPreFileUploadResponseDTO callExternalService(
-            ExternalAPIPreFileUploadRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIPreFileUploadRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = requestDTO.toJson();
+        log.debug("Calling external service for pre-process file upload");
         JSONObject responseJson = callExternalService(requestJson,
                 ServiceExtensionTypeEnum.PRE_PROCESS_CONSENT_FILE_UPLOAD);
         return gson.fromJson(responseJson.toString(), ExternalAPIPreFileUploadResponseDTO.class);
@@ -132,12 +138,13 @@ public class ExternalAPIConsentManageUtils {
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIModifiedResponseDTO callExternalService(
-            ExternalAPIPostFileUploadRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIPostFileUploadRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = new JSONObject(requestDTO);
+        log.debug("Calling external service for post-process file upload");
         JSONObject responseJson = callExternalService(requestJson,
                 ServiceExtensionTypeEnum.ENRICH_CONSENT_FILE_RESPONSE);
         return gson.fromJson(responseJson.toString(), ExternalAPIModifiedResponseDTO.class);
@@ -148,12 +155,13 @@ public class ExternalAPIConsentManageUtils {
      *
      * @param requestDTO - Request DTO
      * @return - Response DTO
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     public static ExternalAPIModifiedResponseDTO callExternalServiceForFileRetrieval(
-            ExternalAPIConsentRetrieveRequestDTO requestDTO) throws ConsentManagementException {
+            ExternalAPIConsentRetrieveRequestDTO requestDTO) throws FinancialServicesException {
 
         JSONObject requestJson = requestDTO.toJson();
+        log.debug("Calling external service for file retrieval");
         JSONObject responseJson = callExternalService(requestJson,
                 ServiceExtensionTypeEnum.VALIDATE_CONSENT_FILE_RETRIEVAL);
         return gson.fromJson(responseJson.toString(), ExternalAPIModifiedResponseDTO.class);
@@ -165,25 +173,21 @@ public class ExternalAPIConsentManageUtils {
      * @param requestJson - Request JSON
      * @param serviceType - Service Type
      * @return - Response JSON
-     * @throws ConsentManagementException - Consent Management Exception
+     * @throws FinancialServicesException - If there is an error while calling the external service
      */
     private static JSONObject callExternalService(
-            JSONObject requestJson, ServiceExtensionTypeEnum serviceType) throws ConsentManagementException {
+            JSONObject requestJson, ServiceExtensionTypeEnum serviceType) throws FinancialServicesException {
 
-        try {
-            ExternalServiceRequest externalServiceRequest = new ExternalServiceRequest(
-                    UUID.randomUUID().toString(), requestJson);
-            ExternalServiceResponse response =
-                    ServiceExtensionUtils.invokeExternalServiceCall(externalServiceRequest, serviceType);
-            if (response.getStatus().equals(StatusEnum.ERROR)) {
-                ExternalAPIUtil.handleResponseError(response);
-            }
-            if (response.getData() == null) {
-                return new JSONObject();
-            }
-            return new JSONObject(response.getData().toString());
-        } catch (FinancialServicesException e) {
-            throw new ConsentManagementException("Error occurred while invoking external service call", e);
+        ExternalServiceRequest externalServiceRequest = new ExternalServiceRequest(
+                UUID.randomUUID().toString(), requestJson);
+        ExternalServiceResponse response =
+                ServiceExtensionUtils.invokeExternalServiceCall(externalServiceRequest, serviceType);
+        if (response.getStatus().equals(StatusEnum.ERROR)) {
+            ExternalAPIUtil.handleResponseError(response);
         }
+        if (response.getData() == null) {
+            return new JSONObject();
+        }
+        return new JSONObject(response.getData().toString());
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/FSDefaultAuthServletImplTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/FSDefaultAuthServletImplTest.java
@@ -36,6 +36,7 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.internal.C
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.util.TestConstants;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
@@ -70,6 +71,8 @@ public class FSDefaultAuthServletImplTest {
     public void initClass() {
 
         httpServletRequestMock = mock(HttpServletRequest.class);
+        Locale locale = new Locale("en", "US");
+        doReturn(locale).when(httpServletRequestMock).getLocale();
         resourceBundle = mock(ResourceBundle.class);
         mockHolder = mock(ConsentExtensionsDataHolder.class);
         mockConfigService = mock(FinancialServicesConfigurationService.class);


### PR DESCRIPTION
## Fixing issue in handling 400 & 500 responses from service extension

> This PR fixes throwing 500 error with a common error message when a 400 or 500 is returned from the service extension.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/770*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
