### PR TITLE
[OB4] Account selection page segregation feature

### DIFF
--- a/financial-services-accelerator/accelerators/fs-is/carbon-home/repository/resources/conf/templates/repository/conf/financial-services.xml.j2
+++ b/financial-services-accelerator/accelerators/fs-is/carbon-home/repository/resources/conf/templates/repository/conf/financial-services.xml.j2
@@ -239,6 +239,11 @@
                 <Enabled>false</Enabled>
             {% endif %}
         </AmendmentHistory>
+        <AuthorizeJSP>
+            {% if financial_services.consent.authorize_jsp.path is defined %}
+                <Path>{{financial_services.consent.authorize_jsp.path}}</Path>
+            {% endif %}
+        </AuthorizeJSP>
     </Consent>
     <Identity>
         <AuthenticationWebApp>

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeConstants.java
@@ -49,6 +49,7 @@ public class ConsentAuthorizeConstants {
     public static final String ACCOUNTS = "accounts";
     public static final String INITIATED_ACCOUNTS = "initiatedAccounts";
     public static final String ALLOW_MULTIPLE_ACCOUNTS = "allowMultipleAccounts";
+    public static final String HANDLE_ACCOUNT_SELECTION_SEPARATELY = "handleAccountSelectionSeparately";
     public static final String CONSUMER_ACCOUNTS = "consumerAccounts";
     public static final String UID = "uid";
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Constants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Constants.java
@@ -66,6 +66,7 @@ public class Constants {
     public static final String IF_STOP_DATA_SHARING_KEY = "if.stop.data.sharing";
     public static final String DO_YOU_CONFIRM_KEY = "do.you.confirm";
     public static final String CONFIRM_BUTTON_KEY = "button.confirm";
+    public static final String NEXT_BUTTON_KEY = "button.next";
     public static final String DENY_BUTTON_KEY = "button.deny";
     public static final String GO_BACK_BUTTON_KEY = "button.goback";
     public static final String APP_REQUESTS_DETAILS = "appRequestsDetails";
@@ -79,6 +80,7 @@ public class Constants {
     public static final String IF_STOP_DATA_SHARING = "ifStopDataSharing";
     public static final String DO_YOU_CONFIRM = "doYouConfirm";
     public static final String CONFIRM_BUTTON = "buttonConfirm";
+    public static final String NEXT_BUTTON = "buttonNext";
     public static final String DENY_BUTTON = "buttonDeny";
     public static final String GO_BACK_BUTTON = "buttonGoBack";
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Utils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authservlet/utils/Utils.java
@@ -179,6 +179,7 @@ public class Utils {
         List<Object> initiatedAccountsForConsent = null;
         Boolean isReauthorization = false;
         Boolean allowMultipleAccounts = false;
+        Boolean handleAccountSelectionSeparately = false;
         String type = null;
 
         if (consentData != null) {
@@ -192,6 +193,8 @@ public class Utils {
                     ConsentAuthorizeConstants.IS_REAUTHORIZATION, false);
             allowMultipleAccounts = (Boolean) consentData.getOrDefault(
                     ConsentAuthorizeConstants.ALLOW_MULTIPLE_ACCOUNTS, false);
+            handleAccountSelectionSeparately = (Boolean) consentData.getOrDefault(
+                    ConsentAuthorizeConstants.HANDLE_ACCOUNT_SELECTION_SEPARATELY, false);
             type = (String) consentData.getOrDefault(
                     ConsentAuthorizeConstants.TYPE, null);
         }
@@ -207,6 +210,8 @@ public class Utils {
         attributeMap.put(ConsentAuthorizeConstants.INITIATED_ACCOUNTS_FOR_CONSENT, initiatedAccountsForConsent);
         attributeMap.put(Constants.CONSUMER_ACCOUNTS, consumerAccounts);
         attributeMap.put(ConsentAuthorizeConstants.ALLOW_MULTIPLE_ACCOUNTS, allowMultipleAccounts);
+        attributeMap.put(ConsentAuthorizeConstants.HANDLE_ACCOUNT_SELECTION_SEPARATELY,
+                handleAccountSelectionSeparately);
         attributeMap.put(ConsentAuthorizeConstants.IS_REAUTHORIZATION, isReauthorization);
         attributeMap.put(ConsentAuthorizeConstants.TYPE, type);
         attributeMap.put(ConsentAuthorizeConstants.HAS_MULTIPLE_PERMISSIONS,
@@ -292,6 +297,8 @@ public class Utils {
                 Constants.IF_STOP_DATA_SHARING_KEY));
         dataFromResourceBundle.put(Constants.CONFIRM_BUTTON, i18n(resourceBundle,
                 Constants.CONFIRM_BUTTON_KEY));
+        dataFromResourceBundle.put(Constants.NEXT_BUTTON, i18n(resourceBundle,
+                Constants.NEXT_BUTTON_KEY));
         dataFromResourceBundle.put(Constants.DENY_BUTTON, i18n(resourceBundle,
                 Constants.DENY_BUTTON_KEY));
         dataFromResourceBundle.put(Constants.GO_BACK_BUTTON, i18n(resourceBundle,

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
@@ -185,7 +185,7 @@ public class FSConsentServlet extends HttpServlet {
         updatedValues.forEach(originalRequest.getSession()::setAttribute);
 
         // If the account selection is to be handled separately, forward to the account selection JSP
-        Object consentDataObj = dataSet.get(ConsentAuthorizeConstants.CONSENT_DATA);
+        Object consentDataObj = dataSet.opt(ConsentAuthorizeConstants.CONSENT_DATA);
         if (consentDataObj instanceof JSONObject) {
             JSONObject consentData = (JSONObject) consentDataObj;
             if (consentData.has(ConsentAuthorizeConstants.HANDLE_ACCOUNT_SELECTION_SEPARATELY)) {
@@ -210,6 +210,11 @@ public class FSConsentServlet extends HttpServlet {
                     return;
                 }
             }
+        } else {
+            log.error("Consent data is not available or not in the expected format");
+            request.getSession().invalidate();
+            response.sendRedirect("retry.do?status=Error&statusMsg=Error while processing request");
+            return;
         }
 
         // dispatch

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
@@ -193,19 +193,19 @@ public class FSConsentServlet extends HttpServlet {
                         .optBoolean(ConsentAuthorizeConstants.HANDLE_ACCOUNT_SELECTION_SEPARATELY, false);
 
                 if (handleAccountSelectionSeparately) {
+                    log.debug("Handling account selection separately, forwarding to account selection page");
 
                     // dispatch
                     RequestDispatcher dispatcher = this.getServletContext()
                             .getRequestDispatcher("/fs_default_account_selection.jsp");
                     dispatcher.forward(originalRequest, response);
-                    return;
                 } else {
+                    log.debug("Handling consent in default flow, forwarding to default consent page");
 
                     // dispatch
                     RequestDispatcher dispatcher = this.getServletContext()
                             .getRequestDispatcher("/fs_default.jsp");
                     dispatcher.forward(originalRequest, response);
-                    return;
                 }
             }
         }

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/java/org/wso2/financial/services/accelerator/authentication/endpoint/FSConsentServlet.java
@@ -199,6 +199,7 @@ public class FSConsentServlet extends HttpServlet {
                     RequestDispatcher dispatcher = this.getServletContext()
                             .getRequestDispatcher("/fs_default_account_selection.jsp");
                     dispatcher.forward(originalRequest, response);
+                    return;
                 } else {
                     log.debug("Handling consent in default flow, forwarding to default consent page");
 
@@ -206,6 +207,7 @@ public class FSConsentServlet extends HttpServlet {
                     RequestDispatcher dispatcher = this.getServletContext()
                             .getRequestDispatcher("/fs_default.jsp");
                     dispatcher.forward(originalRequest, response);
+                    return;
                 }
             }
         }

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/resources/org/wso2/financial/services/accelerator/authentication/endpoint/i18n.properties
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/resources/org/wso2/financial/services/accelerator/authentication/endpoint/i18n.properties
@@ -135,4 +135,5 @@ if.stop.data.sharing=If you want to stop sharing data, you can request us to sto
 do.you.confirm=Do you confirm that we can share your data with {0}?
 button.deny=Deny
 button.confirm=Confirm
+button.next=Next
 button.goback=Go Back

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -119,4 +119,16 @@
         <url-pattern>/retry.do</url-pattern>
     </servlet-mapping>
 
+    <!--  7 -->
+
+    <servlet>
+        <servlet-name>fs_default.do</servlet-name>
+        <jsp-file>/fs_default.jsp</jsp-file>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>fs_default.do</servlet-name>
+        <url-pattern>/fs_default.do</url-pattern>
+    </servlet-mapping>
+
 </web-app>

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/fs_default.jsp
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/fs_default.jsp
@@ -59,14 +59,20 @@
                                             <%--Display basic consent data--%>
                                             <jsp:include page="includes/basic-consent-data.jsp"/>
 
-                                            <c:if test="${not empty permissions}">
-                                                <%-- If permissions are specified --%>
-                                                <jsp:include page="includes/accounts-with-permissions.jsp"/>
-                                            </c:if>
-                                            <c:if test="${empty permissions}">
-                                                <%-- If permissions are not specified --%>
-                                                <jsp:include page="includes/accounts.jsp"/>
-                                            </c:if>
+                                            <c:choose>
+                                                <c:when test="${handleAccountSelectionSeparately}">
+                                                    <%-- If account selection is handled separately --%>
+                                                    <jsp:include page="includes/selected-accounts.jsp"/>
+                                                </c:when>
+                                                <c:when test="${not empty permissions}">
+                                                    <%-- If permissions are specified --%>
+                                                    <jsp:include page="includes/accounts-with-permissions.jsp"/>
+                                                </c:when>
+                                                <c:when test="${empty permissions}">
+                                                    <%-- If permissions are not specified --%>
+                                                    <jsp:include page="includes/accounts.jsp"/>
+                                                </c:when>
+                                            </c:choose>
                                         </div>
                                     </div>
 

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/fs_default_account_selection.jsp
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/fs_default_account_selection.jsp
@@ -1,5 +1,5 @@
 <%--
-~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 ~
 ~ WSO2 LLC. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/fs_default_account_selection.jsp
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/fs_default_account_selection.jsp
@@ -1,0 +1,106 @@
+<%--
+~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+~
+~ WSO2 LLC. licenses this file to you under the Apache License,
+~ Version 2.0 (the "License"); you may not use this file except
+~ in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied. See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+--%>
+
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<% response.setCharacterEncoding("UTF-8"); %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Map" %>
+
+<%@ taglib prefix = "fmt" uri = "http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix = "c" uri = "http://java.sun.com/jsp/jstl/core" %>
+
+<%
+    session.setAttribute("initiatedAccountsForConsent", request.getAttribute("initiatedAccountsForConsent"));
+    session.setAttribute("selectAccounts", request.getAttribute("selectAccounts"));
+    session.setAttribute("reAuthenticationDisclaimer", request.getAttribute("reAuthenticationDisclaimer"));
+    session.setAttribute("dataRequested", request.getAttribute("dataRequested"));
+    session.setAttribute("buttonGoBack", request.getAttribute("buttonGoBack"));
+    session.setAttribute("defaultSelect", request.getAttribute("defaultSelect"));
+    session.setAttribute("buttonDeny", request.getAttribute("buttonDeny"));
+    session.setAttribute("consumerAccounts", request.getAttribute("consumerAccounts"));
+    session.setAttribute("type", request.getAttribute("type"));
+    session.setAttribute("basicConsentData", request.getAttribute("basicConsentData"));
+    session.setAttribute("hasMultiplePermissions", request.getAttribute("hasMultiplePermissions"));
+    session.setAttribute("textDirection", request.getAttribute("textDirection"));
+    session.setAttribute("ifStopDataSharing", request.getAttribute("ifStopDataSharing"));
+    session.setAttribute("permissions", request.getAttribute("permissions"));
+    session.setAttribute("allowMultipleAccounts", request.getAttribute("allowMultipleAccounts"));
+    session.setAttribute("appRequestsDetails", request.getAttribute("appRequestsDetails"));
+    session.setAttribute("requestedPermissions", request.getAttribute("requestedPermissions"));
+    session.setAttribute("noConsumerAccounts", request.getAttribute("noConsumerAccounts"));
+    session.setAttribute("isReauthorization", request.getAttribute("isReauthorization"));
+    session.setAttribute("buttonNext", request.getAttribute("buttonNext"));
+    session.setAttribute("doYouConfirm", request.getAttribute("doYouConfirm"));
+    session.setAttribute("handleAccountSelectionSeparately", request.getAttribute("handleAccountSelectionSeparately"));
+    session.setAttribute("onFollowingAccounts", request.getAttribute("onFollowingAccounts"));
+    session.setAttribute("buttonOk", request.getAttribute("buttonOk"));
+%>
+
+<html>
+    <head>
+        <jsp:include page="includes/head.jsp"/>
+        <script src="js/auth-functions.js"></script>
+    </head>
+
+    <body dir="${textDirection}">
+        <div class="page-content-wrapper" style="position: relative; min-height: 100vh;">
+            <div class="container-fluid " style="padding-bottom: 40px">
+                <div class="container">
+                    <div class="login-form-wrapper">
+
+                        <%--Display consent open banking logo--%>
+                        <jsp:include page="includes/logo.jsp"/>
+
+                        <div class="row data-container">
+                            <div class="clearfix"></div>
+                            <form action="${pageContext.request.contextPath}/fs_default.do" method="post" id="oauth2_authz_account_selection"
+                                  name="oauth2_authz_account_selection" class="form-horizontal">
+                                <div class="login-form">
+                                    <div class="form-group ui form">
+                                        <div class="col-md-12 ui box">
+
+                                            <%--Display consent page header--%>
+                                            <h3 class="ui header">
+                                                ${appRequestsDetails}
+                                            </h3>
+
+                                            <%--Display accounts to select--%>
+                                            <jsp:include page="includes/accounts.jsp"/>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-group ui form row">
+                                        <div class="ui body col-md-12">
+                                            <input type="button" class="btn btn-primary" id="next" name="next"
+                                                    onclick="javascript: accountsSelected(); return false;"
+                                                    value="${buttonNext}"/>
+                                        </div>
+                                    </div>
+
+                                    <jsp:include page="includes/privacy-footer.jsp"/>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <jsp:include page="includes/footer.jsp"/>
+        </div>
+    </body>
+</html>

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/includes/selected-accounts.jsp
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/includes/selected-accounts.jsp
@@ -1,0 +1,42 @@
+<%--
+~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+~
+~ WSO2 LLC. licenses this file to you under the Apache License,
+~ Version 2.0 (the "License"); you may not use this file except
+~ in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied. See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+--%>
+
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix = "c" uri = "http://java.sun.com/jsp/jstl/core" %>
+
+<%-- View accounts selected from the account selection page --%>
+<c:choose>
+    <c:when test="${not empty paramValues.accounts}">
+        <h5 class="ui body col-md-12">
+            ${onFollowingAccounts}
+        </h5>
+        <b>
+            <ul class="scopes-list padding padding-left-triple">
+                <c:forEach items="${paramValues.accounts}" var="account">
+                    <li>${account}</li>
+                    <%-- Passing the selected accounts parameter to the persist flow --%>
+                    <input type="hidden" name="accounts" value="${account}" />
+                </c:forEach>
+            </ul>
+        </b>
+    </c:when>
+    <%-- Display error --%>
+    <c:otherwise>
+        <b>${noConsumerAccounts}</b>
+    </c:otherwise>
+</c:choose>

--- a/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/js/auth-functions.js
+++ b/financial-services-accelerator/internal-webapps/org.wso2.financial.services.accelerator.authentication.endpoint/src/main/webapp/js/auth-functions.js
@@ -29,6 +29,11 @@ function approvedConsent() {
     document.getElementById("oauth2_authz_confirm").submit();
 }
 
+// Confirm accounts selected
+function accountsSelected() {
+    document.getElementById("oauth2_authz_account_selection").submit();
+}
+
 // Set permission uids as names for account inputs before submission
 function updateAccountNamesFromPermissions() {
     const hiddenPermissions = document.querySelectorAll('input[type="hidden"][name^="permission-"]');


### PR DESCRIPTION
## Purpose
This PR contains the feature for segregating the account selection page from the consent confirmation page using a json response attribute coming from the https://ob.docs.wso2.com/en/latest/develop/openapi-consent-management-authorize/#openapi-extensions service extension.

The attribute "handleAccountSelectionSeparately" has been introduced, if true, it displays the accounts in a separate page else it displays the accounts along with the other consent data then the consent can be confirmed from the same page.

## Flow
When a response like the following is sent for the populate-consent-authorize-screen service extension:
```
{
  "responseId": "9578b3dc-ddc8-454e-8998-ed9472448810",
  "status": "SUCCESS",
  "data": {
    "consentData": {
      "initiatedAccountsForConsent": [],
      "allowMultipleAccounts": true,
      "isReauthorization": false,
      "handleAccountSelectionSeparately": true,
      "additionalProperties": {},
      "type": "accounts",
      "basicConsentData": {
        "Transaction From Date Time": [
          "2025-02-20T00:00:00+00:00"
        ],
        "Transaction To Date Time": [
          "2025-03-10T00:00:00+00:00"
        ],
        "Expiration Date Time": [
          "2025-10-02T00:00:00+00:00"
        ]
      }
    },
    "consumerData": {
      "accounts": [
        {
          "displayName": "account_1",
          "additionalProperties": {},
          "selected": false
        },
        {
          "displayName": "account_2",
          "additionalProperties": {},
          "selected": false
        },
        {
          "displayName": "multi_auth_account",
          "additionalProperties": {},
          "selected": false
        },
        {
          "displayName": "Extra_account",
          "additionalProperties": {},
          "selected": false
        }
      ],
      "additionalProperties": {}
    }
  }
}
```

1st page will look like this:
<img width="1401" height="604" alt="image" src="https://github.com/user-attachments/assets/18bf4980-8e13-403c-ab8c-966118b6c42a" />

and the 2nd page will look like this:
<img width="1401" height="866" alt="image" src="https://github.com/user-attachments/assets/962e3d1c-b8e2-4b6f-8dd1-aa40ac118031" />

This feature also provided a configuration as a fallback when the json attribute "handleAccountSelectionSeparately" is not sent in the service response, it can also be used to direct the whole consent approval flow to totally custom flow by configuring a custom jsp

**Issue link:** *required*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
