### PR TITLE
[3.0.0] Fixing consent manager loading issue when cookies are set to http only

### DIFF
--- a/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/common/Nav.jsx
+++ b/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/common/Nav.jsx
@@ -34,7 +34,7 @@ import { userIdAdjustment } from "../services/utils.js";
 export const Nav = (user) => {
 
   const handleLogout = () => {
-    logout(user.idToken)
+    logout()
   };
 
   const showQR = () => {

--- a/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/config.js
+++ b/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/config.js
@@ -30,8 +30,6 @@ export const CONFIG = {
     TENANT_DOMAIN:window.env.TENANT_DOMAIN,
     TOKEN_ENDPOINT: serverUrl + "/oauth2/token",
     AUTHORIZE_ENDPOINT: serverUrl + "/consentmgr/scp_oauth2_authorize",
-    LOGOUT_URL: serverUrl + "/oidc/logout",
-    REDIRECT_URI: serverUrl + "/consentmgr/scp_oauth2_callback",
     BACKEND_URL: serverUrl + "/consentmgr/scp",
     NUMBER_OF_CONSENTS: window.env.NUMBER_OF_CONSENTS,
     VERSION: window.env.VERSION,

--- a/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/data/User.js
+++ b/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/data/User.js
@@ -15,37 +15,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { id } from "date-fns/locale";
+import axios from "axios";
 import Cookies from "js-cookie";
+import { CONFIG } from "../config";
 
 export default class User {
-  constructor() {
-    let idToken = getIdToken();
-
-    if (idToken) {
+  constructor(userInfo) {
+    if (userInfo && userInfo.isLogged) {
       this.isLogged = true;
-      this.idToken = idToken;
-      this.email = decodeIdToken(idToken).sub;
-      this.role = decodeIdToken(idToken).user_role;
+      this.email = userInfo.email;
+      this.role = userInfo.role;
     } else {
       this.isLogged = false;
     }
   }
-}
 
-/**
- * Concat id_token cookies and return token
- * @returns {String|null} - If cookies found, return its value, Else null value is returned
- */
-const getIdToken = () => {
-  const idTokenPart1 = Cookies.get(User.CONST.OB_SCP_ID_TOKEN_P1);
-  const idTokenPart2 = Cookies.get(User.CONST.OB_SCP_ID_TOKEN_P2);
-
-  if (!idTokenPart1 || !idTokenPart2) {
-    return null;
+  /**
+   * Fetch the logged-in user's info from the backend. The id token used to derive this info is decoded
+   * server-side from its HttpOnly cookies and never reaches the browser as JavaScript-readable data.
+   * @returns {Promise<User>} - Resolves to a logged-in User on success, or a logged-out User otherwise
+   */
+  static async load() {
+    try {
+      const response = await axios.get(`${CONFIG.BACKEND_URL}/userinfo`, {
+        withCredentials: true,
+      });
+      return new User(response.data);
+    } catch (error) {
+      return new User(null);
+    }
   }
-  return idTokenPart1 + idTokenPart2;
-};
+}
 
 export const getAccessToken = () => {
   const accessTokenPart1 = Cookies.get(User.CONST.OB_SCP_ACC_TOKEN_P1);
@@ -57,15 +57,9 @@ export const getAccessToken = () => {
   return accessTokenPart1 + accessTokenPart2;
 };
 
-export function decodeIdToken(token) {
-  return JSON.parse(atob(token.split(".")[1]));
-}
-
 User.CONST = {
   OB_SCP_ACC_TOKEN_P1: "OB_SCP_AT_P1",
   OB_SCP_ACC_TOKEN_P2: "OB_SCP_AT_P2",
-  OB_SCP_ID_TOKEN_P1: "OB_SCP_IT_P1",
-  OB_SCP_ID_TOKEN_P2: "OB_SCP_IT_P2",
   OB_SCP_REF_TOKEN_P1: "OB_SCP_RT_P1",
   OB_SCP_REF_TOKEN_P2: "OB_SCP_RT_P2",
 };

--- a/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/login/login.js
+++ b/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/login/login.js
@@ -30,12 +30,15 @@ export const Login = () => {
   const [user, setLoggedUser] = useState({});
 
   useEffect(() => {
-    // this object contains user details
-    let user = new User();
-    setLoggedUser(user);
-    setIsLoggedIn(user.isLogged);
-    setIsLoading(false);
-    setContextUser(user);
+    const fetchUser = async () => {
+      // this object contains user details
+      const user = await User.load();
+      setLoggedUser(user);
+      setIsLoggedIn(user.isLogged);
+      setIsLoading(false);
+      setContextUser(user);
+    };
+    fetchUser();
   },[]);
 
   const renderLoading = () => {

--- a/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/login/logout.js
+++ b/react-apps/self-care-portal/self-care-portal-frontend/accelerator/src/login/logout.js
@@ -18,7 +18,9 @@
 
 import {CONFIG} from "../config"
 
-export const logout = (idToken) => {
-    window.location.href = `${CONFIG.LOGOUT_URL}?id_token_hint=${idToken}&post_logout_redirect_uri=${CONFIG.REDIRECT_URI}`;
+export const logout = () => {
+    // the backend builds the identity server logout redirect (with id_token_hint) server-side,
+    // since the id token is HttpOnly and never available to frontend JavaScript
+    window.location.href = `${CONFIG.BACKEND_URL}/logout`;
     localStorage.setItem("userId" , null)
 }

--- a/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/service/APIMService.java
+++ b/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/service/APIMService.java
@@ -86,6 +86,26 @@ public class APIMService implements Serializable {
         return Optional.empty();
     }
 
+    /**
+     * Reconstruct the id token from its two cookie halves. Both halves are HttpOnly and are read here
+     * server-side only, so the id token itself is never exposed to frontend JavaScript.
+     *
+     * @param req the servlet request carrying the id token cookies
+     * @return the reconstructed id token, if both cookie halves are present
+     */
+    public Optional<String> constructIdTokenFromCookies(HttpServletRequest req) {
+        Optional<Cookie> idTokenPart1 = Utils
+                .getCookieFromRequest(req, Constants.ID_TOKEN_COOKIE_NAME + "_P1");
+
+        Optional<Cookie> idTokenPart2 = Utils
+                .getCookieFromRequest(req, Constants.ID_TOKEN_COOKIE_NAME + "_P2");
+
+        if (idTokenPart1.isPresent() && idTokenPart2.isPresent()) {
+            return Optional.of(idTokenPart1.get().getValue() + idTokenPart2.get().getValue());
+        }
+        return Optional.empty();
+    }
+
     public void forwardRequest(HttpServletResponse resp, HttpUriRequest httpRequest, Map<String, String> headers)
             throws TokenGenerationException {
         // adding headers to request

--- a/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/service/OAuthService.java
+++ b/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/service/OAuthService.java
@@ -80,6 +80,26 @@ public class OAuthService {
         return authUri.toString();
     }
 
+    /**
+     * Build the identity server's RP-initiated logout URL. Constructed entirely server-side so that the
+     * raw id token never needs to be handed to frontend JavaScript to perform a logout redirect.
+     *
+     * @param iamBaseUrl base url of the identity server
+     * @param idToken    the id token to pass as id_token_hint, may be null/empty if the session already expired
+     * @return the logout url to redirect the browser to
+     */
+    public String generateLogoutUrl(String iamBaseUrl, String idToken) throws URISyntaxException {
+        URIBuilder logoutUriBuilder = new URIBuilder(iamBaseUrl)
+                .setPath(Constants.PATH_LOGOUT)
+                .addParameter(Constants.POST_LOGOUT_REDIRECT_URI, iamBaseUrl + Constants.PATH_CALLBACK);
+
+        if (StringUtils.isNotEmpty(idToken)) {
+            logoutUriBuilder.addParameter(Constants.ID_TOKEN_HINT, idToken);
+        }
+
+        return logoutUriBuilder.build().toString();
+    }
+
     private JSONObject sendTokenRequest(String iamBaseUrl, String clientKey, String clientSecret, List<NameValuePair>
             params) throws UnsupportedEncodingException, TokenGenerationException {
 
@@ -156,7 +176,7 @@ public class OAuthService {
         cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
         cookie.setPath(path);
-        cookie.setHttpOnly(true);
+        cookie.setHttpOnly(!(Constants.ACCESS_TOKEN_COOKIE_NAME + "_P1").equals(cookieName));
 
         resp.addCookie(cookie);
     }

--- a/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/servlet/LogoutServlet.java
+++ b/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/servlet/LogoutServlet.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.scp.webapp.servlet;
+
+import com.wso2.openbanking.accelerator.common.util.Generated;
+import com.wso2.openbanking.scp.webapp.model.SCPError;
+import com.wso2.openbanking.scp.webapp.service.APIMService;
+import com.wso2.openbanking.scp.webapp.service.OAuthService;
+import com.wso2.openbanking.scp.webapp.util.Constants;
+import com.wso2.openbanking.scp.webapp.util.Utils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * LogoutServlet
+ * <p>
+ * Builds the identity server's RP-initiated logout redirect entirely server-side, using the id token
+ * reconstructed from its HttpOnly cookie halves. This lets the frontend trigger a logout without ever
+ * needing the raw id token in JavaScript.
+ */
+@WebServlet(name = "LogoutServlet", urlPatterns = {"/scp/logout"})
+public class LogoutServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -6816522873204450210L;
+    private static final Log LOG = LogFactory.getLog(LogoutServlet.class);
+    private final APIMService apimService = new APIMService();
+
+    @Generated(message = "Ignoring since all cases are covered from other unit tests")
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+        final String iamBaseUrl = Utils.getParameter(Constants.IS_BASE_URL);
+        final OAuthService oAuthService = OAuthService.getInstance();
+
+        try {
+            Optional<String> optIdToken = apimService.constructIdTokenFromCookies(req);
+            final String logoutUrl = oAuthService.generateLogoutUrl(iamBaseUrl, optIdToken.orElse(null));
+
+            LOG.debug("Invalidating cookies and redirecting to logout url");
+            oAuthService.removeAllCookiesFromRequest(req, resp);
+            resp.sendRedirect(logoutUrl);
+        } catch (URISyntaxException | IOException e) {
+            LOG.error("Exception occurred while redirecting to logout url. Caused by, ", e);
+            oAuthService.removeAllCookiesFromRequest(req, resp);
+            SCPError error = new SCPError("Logout Failed!",
+                    "Something went wrong while signing out. Please try again.");
+            final String errorUrlFormat = iamBaseUrl + "/consentmgr/error?message=%s&description=%s";
+            Utils.sendErrorToFrontend(error, errorUrlFormat, resp);
+        }
+    }
+}

--- a/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/servlet/UserInfoServlet.java
+++ b/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/servlet/UserInfoServlet.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.scp.webapp.servlet;
+
+import com.wso2.openbanking.accelerator.common.util.Generated;
+import com.wso2.openbanking.accelerator.common.util.JWTUtils;
+import com.wso2.openbanking.scp.webapp.model.SCPError;
+import com.wso2.openbanking.scp.webapp.service.APIMService;
+import com.wso2.openbanking.scp.webapp.service.OAuthService;
+import com.wso2.openbanking.scp.webapp.util.Constants;
+import com.wso2.openbanking.scp.webapp.util.Utils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.util.Optional;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * UserInfoServlet
+ * <p>
+ * Decodes the id token server-side (from its HttpOnly cookie halves) and exposes only the claims the
+ * frontend needs (email, role) as JSON. This keeps the id token itself out of reach of frontend JavaScript.
+ */
+@WebServlet(name = "UserInfoServlet", urlPatterns = {"/scp/userinfo"})
+public class UserInfoServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 3902649563217544213L;
+    private static final Log LOG = LogFactory.getLog(UserInfoServlet.class);
+    private final APIMService apimService = new APIMService();
+
+    @Generated(message = "Ignoring since all cases are covered from other unit tests")
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+        Optional<String> optIdToken = apimService.constructIdTokenFromCookies(req);
+
+        if (!optIdToken.isPresent()) {
+            LOG.debug("Id token cookies are missing from the request. Returning unauthenticated response.");
+            Utils.returnResponse(resp, HttpStatus.SC_UNAUTHORIZED, buildUnauthenticatedResponse());
+            return;
+        }
+
+        try {
+            net.minidev.json.JSONObject idTokenBody = JWTUtils.decodeRequestJWT(optIdToken.get(), "body");
+
+            JSONObject userInfo = new JSONObject();
+            userInfo.put("isLogged", true);
+            userInfo.put("email", idTokenBody.getAsString(Constants.CLAIM_SUB));
+            userInfo.put("role", idTokenBody.getAsString(Constants.CLAIM_USER_ROLE));
+
+            Utils.returnResponse(resp, HttpStatus.SC_OK, userInfo);
+        } catch (ParseException e) {
+            LOG.error("Exception occurred while decoding id token. Caused by, ", e);
+            OAuthService.getInstance().removeAllCookiesFromRequest(req, resp);
+            Utils.returnResponse(resp, HttpStatus.SC_UNAUTHORIZED, buildUnauthenticatedResponse());
+        }
+    }
+
+    private JSONObject buildUnauthenticatedResponse() {
+        SCPError error = new SCPError("Authentication Error!",
+                "User session is invalid or has expired. Please sign in again.");
+        return new JSONObject(error);
+    }
+}

--- a/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/util/Constants.java
+++ b/react-apps/self-care-portal/src/main/java/com/wso2/openbanking/scp/webapp/util/Constants.java
@@ -40,6 +40,11 @@ public class Constants {
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final String EXPIRES_IN = "expires_in";
 
+    public static final String ID_TOKEN_HINT = "id_token_hint";
+    public static final String POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
+    public static final String CLAIM_SUB = "sub";
+    public static final String CLAIM_USER_ROLE = "user_role";
+
     public static final String COOKIE_BASE_NAME = "OB_SCP_";
     public static final String ACCESS_TOKEN_COOKIE_NAME = COOKIE_BASE_NAME + "AT";
     public static final String ID_TOKEN_COOKIE_NAME = COOKIE_BASE_NAME + "IT";

--- a/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/service/APIMServiceTest.java
+++ b/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/service/APIMServiceTest.java
@@ -119,6 +119,36 @@ public class APIMServiceTest extends PowerMockTestCase {
         Assert.assertFalse(optAccessToken.isPresent());
     }
 
+    @Test(description = "when valid req, then return id token")
+    public void testConstructIdTokenFromCookiesWithValidReq() {
+        // mock
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+
+        // when
+        Cookie cookie1 = new Cookie(Constants.ID_TOKEN_COOKIE_NAME + "_P1", "dummy-cookie-p1");
+        Cookie cookie2 = new Cookie(Constants.ID_TOKEN_COOKIE_NAME + "_P2", "dummy-cookie-p2");
+
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{cookie1, cookie2});
+
+        // assert
+        Optional<String> optIdToken = uut.constructIdTokenFromCookies(reqMock);
+        Assert.assertTrue(optIdToken.isPresent());
+        Assert.assertEquals(optIdToken.get(), "dummy-cookie-p1dummy-cookie-p2");
+    }
+
+    @Test(description = "when invalid req, then return empty string")
+    public void testConstructIdTokenFromCookiesWithInvalidReq() {
+        // mock
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+
+        // when
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{});
+
+        // assert
+        Optional<String> optIdToken = uut.constructIdTokenFromCookies(reqMock);
+        Assert.assertFalse(optIdToken.isPresent());
+    }
+
     @Test(description = "if access token is not expired return false")
     public void testIsAccessTokenExpired() throws SessionTimeoutException {
         // mock

--- a/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/service/OAuthServiceTest.java
+++ b/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/service/OAuthServiceTest.java
@@ -75,6 +75,26 @@ public class OAuthServiceTest extends PowerMockTestCase {
 
     }
 
+    @Test(description = "method should return a logout url containing the id token hint")
+    public void testGenerateLogoutUrl() throws URISyntaxException {
+        String logoutUrl = uut.generateLogoutUrl(IAM_BASE_URL, "dummy-id-token");
+        URI uri = new URI(logoutUrl);
+
+        Assert.assertEquals(uri.getHost(), "localhost");
+        Assert.assertEquals(uri.getPath(), Constants.PATH_LOGOUT);
+        Assert.assertTrue(uri.getQuery().contains("id_token_hint=dummy-id-token"));
+        Assert.assertTrue(uri.getQuery().contains("post_logout_redirect_uri"));
+    }
+
+    @Test(description = "method should return a logout url without id_token_hint when id token is absent")
+    public void testGenerateLogoutUrlWithoutIdToken() throws URISyntaxException {
+        String logoutUrl = uut.generateLogoutUrl(IAM_BASE_URL, null);
+        URI uri = new URI(logoutUrl);
+
+        Assert.assertFalse(uri.getQuery().contains("id_token_hint"));
+        Assert.assertTrue(uri.getQuery().contains("post_logout_redirect_uri"));
+    }
+
     @Test
     public void testSendAccessTokenRequest() throws TokenGenerationException, UnsupportedEncodingException {
         PowerMockito.mockStatic(Utils.class);

--- a/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/LogoutServletTest.java
+++ b/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/LogoutServletTest.java
@@ -21,12 +21,13 @@ import org.powermock.modules.testng.PowerMockTestCase;
 import org.powermock.reflect.Whitebox;
 import org.testng.annotations.Test;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @PrepareForTest({LogoutServlet.class, Utils.class})
 @PowerMockIgnore("jdk.internal.reflect.*")

--- a/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/LogoutServletTest.java
+++ b/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/LogoutServletTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package com.wso2.openbanking.scp.webapp.servlet;
+
+import com.wso2.openbanking.scp.webapp.service.APIMService;
+import com.wso2.openbanking.scp.webapp.util.Constants;
+import com.wso2.openbanking.scp.webapp.util.Utils;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.powermock.reflect.Whitebox;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+@PrepareForTest({LogoutServlet.class, Utils.class})
+@PowerMockIgnore("jdk.internal.reflect.*")
+public class LogoutServletTest extends PowerMockTestCase {
+
+    private static final String IAM_BASE_URL = "https://localhost:9446";
+
+    @Test(description = "when id token cookies are present, redirect to logout url with id_token_hint")
+    public void testDoGetWithIdToken() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        PowerMockito.mockStatic(Utils.class);
+        PowerMockito.when(Utils.getParameter(Constants.IS_BASE_URL)).thenReturn(IAM_BASE_URL);
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.of("dummy-id-token"));
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{});
+
+        // assert
+        LogoutServlet servlet = new LogoutServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        Mockito.verify(respMock, Mockito.times(1)).sendRedirect(Mockito.argThat(new ArgumentMatcher<String>() {
+            @Override
+            public boolean matches(Object argument) {
+                try {
+                    URI uri = new URI((String) argument);
+                    return uri.getPath().equals(Constants.PATH_LOGOUT)
+                            && uri.getQuery().contains("id_token_hint=dummy-id-token");
+                } catch (URISyntaxException e) {
+                    return false;
+                }
+            }
+        }));
+    }
+
+    @Test(description = "when id token cookies are missing, redirect to logout url without id_token_hint")
+    public void testDoGetWithoutIdToken() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        PowerMockito.mockStatic(Utils.class);
+        PowerMockito.when(Utils.getParameter(Constants.IS_BASE_URL)).thenReturn(IAM_BASE_URL);
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.empty());
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{});
+
+        // assert
+        LogoutServlet servlet = new LogoutServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        Mockito.verify(respMock, Mockito.times(1)).sendRedirect(Mockito.argThat(new ArgumentMatcher<String>() {
+            @Override
+            public boolean matches(Object argument) {
+                return !((String) argument).contains("id_token_hint");
+            }
+        }));
+    }
+
+    @Test(description = "when building the logout url fails, send an error to the frontend and clear cookies")
+    public void testDoGetWithInvalidIamBaseUrl() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+
+        // when: an unparsable iam base url causes generateLogoutUrl to throw URISyntaxException
+        PowerMockito.mockStatic(Utils.class);
+        PowerMockito.when(Utils.getParameter(Constants.IS_BASE_URL)).thenReturn("not a valid uri");
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.empty());
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{});
+        Mockito.doNothing().when(respMock).sendRedirect(Mockito.anyString());
+
+        // assert
+        LogoutServlet servlet = new LogoutServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        PowerMockito.verifyStatic(Utils.class, Mockito.times(1));
+        Utils.sendErrorToFrontend(Mockito.any(), Mockito.anyString(), Mockito.eq(respMock));
+        Mockito.verify(respMock, Mockito.never()).sendRedirect(Mockito.anyString());
+    }
+
+    @Test(description = "regardless of outcome, all self-care-portal cookies are invalidated")
+    public void testDoGetInvalidatesCookies() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+        Cookie cookie = new Cookie(Constants.COOKIE_BASE_NAME + "1", "dummy-cookie");
+
+        // when
+        PowerMockito.mockStatic(Utils.class);
+        PowerMockito.when(Utils.getParameter(Constants.IS_BASE_URL)).thenReturn(IAM_BASE_URL);
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.empty());
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{cookie});
+
+        // assert
+        LogoutServlet servlet = new LogoutServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        Mockito.verify(respMock, Mockito.times(1)).addCookie(Mockito.any(Cookie.class));
+    }
+}

--- a/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/UserInfoServletTest.java
+++ b/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/UserInfoServletTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package com.wso2.openbanking.scp.webapp.servlet;
+
+import com.wso2.openbanking.scp.webapp.service.APIMService;
+import com.wso2.openbanking.scp.webapp.util.Utils;
+import org.apache.http.HttpStatus;
+import org.json.JSONObject;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.powermock.reflect.Whitebox;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
+@PrepareForTest({UserInfoServlet.class, Utils.class})
+@PowerMockIgnore("jdk.internal.reflect.*")
+public class UserInfoServletTest extends PowerMockTestCase {
+
+    @Test(description = "when id token cookies are missing, return an unauthenticated response")
+    public void testDoGetWithoutIdToken() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        PowerMockito.mockStatic(Utils.class);
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.empty());
+
+        // assert
+        UserInfoServlet servlet = new UserInfoServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        ArgumentCaptor<JSONObject> payloadCaptor = ArgumentCaptor.forClass(JSONObject.class);
+        PowerMockito.verifyStatic(Utils.class, Mockito.times(1));
+        Utils.returnResponse(Mockito.eq(respMock), Mockito.eq(HttpStatus.SC_UNAUTHORIZED), payloadCaptor.capture());
+        Assert.assertFalse(payloadCaptor.getValue().has("email"));
+    }
+
+    @Test(description = "when a valid id token is present, return the user's email and role")
+    public void testDoGetWithValidIdToken() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        PowerMockito.mockStatic(Utils.class);
+        String idToken = buildIdToken("jdoe@wso2.com", "admin");
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.of(idToken));
+
+        // assert
+        UserInfoServlet servlet = new UserInfoServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        ArgumentCaptor<JSONObject> payloadCaptor = ArgumentCaptor.forClass(JSONObject.class);
+        PowerMockito.verifyStatic(Utils.class, Mockito.times(1));
+        Utils.returnResponse(Mockito.eq(respMock), Mockito.eq(HttpStatus.SC_OK), payloadCaptor.capture());
+
+        JSONObject userInfo = payloadCaptor.getValue();
+        Assert.assertTrue(userInfo.getBoolean("isLogged"));
+        Assert.assertEquals(userInfo.getString("email"), "jdoe@wso2.com");
+        Assert.assertEquals(userInfo.getString("role"), "admin");
+    }
+
+    @Test(description = "when the id token cannot be parsed, clear cookies and return an unauthenticated response")
+    public void testDoGetWithMalformedIdToken() throws Exception {
+        // mock
+        APIMService apimServiceMock = Mockito.mock(APIMService.class);
+        PowerMockito.whenNew(APIMService.class).withNoArguments().thenReturn(apimServiceMock);
+
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse respMock = Mockito.mock(HttpServletResponse.class);
+        Cookie cookie = new Cookie("OB_SCP_IT_P1", "dummy-cookie");
+
+        // when
+        PowerMockito.mockStatic(Utils.class);
+        Mockito.when(apimServiceMock.constructIdTokenFromCookies(reqMock)).thenReturn(Optional.of("not-a-jwt"));
+        Mockito.when(reqMock.getCookies()).thenReturn(new Cookie[]{cookie});
+
+        // assert
+        UserInfoServlet servlet = new UserInfoServlet();
+        Whitebox.invokeMethod(servlet, "doGet", reqMock, respMock);
+
+        Mockito.verify(respMock, Mockito.times(1)).addCookie(Mockito.any(Cookie.class));
+        PowerMockito.verifyStatic(Utils.class, Mockito.times(1));
+        Utils.returnResponse(Mockito.eq(respMock), Mockito.eq(HttpStatus.SC_UNAUTHORIZED),
+                Mockito.any(JSONObject.class));
+    }
+
+    /**
+     * Builds a JWS compact serialization with the given claims. The signature segment is a placeholder since
+     * {@code JWTUtils.decodeRequestJWT} only decodes the header/payload segments and never verifies the signature.
+     */
+    private String buildIdToken(String subject, String role) {
+        String header = encodeSegment("{\"alg\":\"HS256\"}");
+        String payload = encodeSegment(String.format("{\"sub\":\"%s\",\"user_role\":\"%s\"}", subject, role));
+        return header + "." + payload + ".signature";
+    }
+
+    private String encodeSegment(String json) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/UserInfoServletTest.java
+++ b/react-apps/self-care-portal/src/test/java/com/wso2/openbanking/scp/webapp/servlet/UserInfoServletTest.java
@@ -23,12 +23,13 @@ import org.powermock.reflect.Whitebox;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @PrepareForTest({UserInfoServlet.class, Utils.class})
 @PowerMockIgnore("jdk.internal.reflect.*")

--- a/react-apps/self-care-portal/src/test/resources/testng.xml
+++ b/react-apps/self-care-portal/src/test/resources/testng.xml
@@ -24,6 +24,8 @@
             <class name="com.wso2.openbanking.scp.webapp.service.APIMServiceTest"/>
             <class name="com.wso2.openbanking.scp.webapp.service.OAuthServiceTest"/>
             <class name="com.wso2.openbanking.scp.webapp.util.UtilsTest"/>
+            <class name="com.wso2.openbanking.scp.webapp.servlet.LogoutServletTest"/>
+            <class name="com.wso2.openbanking.scp.webapp.servlet.UserInfoServletTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Fixing consent manager loading issue when cookies are set to http only

> This PR fixes consent manager loading issue when cookies are set to http only

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/998*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
