### PR TITLE
Fixing consent manager loading issue when cookies are set to http only

### DIFF
--- a/financial-services-accelerator/react-apps/self-care-portal/src/main/java/org/wso2/financial/services/accelerator/scp/webapp/service/OAuthService.java
+++ b/financial-services-accelerator/react-apps/self-care-portal/src/main/java/org/wso2/financial/services/accelerator/scp/webapp/service/OAuthService.java
@@ -184,11 +184,10 @@ public class OAuthService {
         cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
         cookie.setPath(path);
-        // Access token halves must stay JS-readable: the frontend reads them to send the
-        // Authorization header (SplitTokenValve CSRF pattern) and to reconstruct the token for
-        // Popup.jsx's device registration call. Everything else (id token, refresh token,
-        // validity marker) is only ever read server-side, so it can be locked down.
-        cookie.setHttpOnly(!cookieName.startsWith(Constants.ACCESS_TOKEN_COOKIE_NAME));
+        // One half of the Access token must stay JS-readable: the frontend reads it to send the
+        // Authorization header (SplitTokenValve CSRF pattern). Everything else (remaining half of the access token,
+        // id token, refresh token, validity marker) is only ever read server-side, so it can be locked down.
+        cookie.setHttpOnly(!(Constants.ACCESS_TOKEN_COOKIE_NAME + "_P1").equals(cookieName));
 
         resp.addCookie(cookie);
     }


### PR DESCRIPTION
## Fixing consent manager loading issue when cookies are set to http only

> This PR fixes consent manager loading issue when cookies are set to http only

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/998*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
