### PR TITLE
[FS4] Fixes same Common Auth ID issue

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
@@ -156,6 +156,9 @@ public class DefaultConsentPersistStep implements ConsentPersistStep {
             if (consentPersistData.getBrowserCookies() != null) {
                 String commonAuthId = consentPersistData.getBrowserCookies().get(
                         ConsentExtensionConstants.COMMON_AUTH_ID);
+                // Detach the commonAuthId from the consents it is already mapped to, so that only the consent
+                // being persisted now is resolvable using the commonAuthId of this browser session.
+                ConsentAuthorizeUtil.removeCommonAuthIdFromExistingConsents(consentCoreService, commonAuthId);
                 Map<String, String> consentAttributes = new HashMap<>();
                 consentAttributes.put(ConsentExtensionConstants.COMMON_AUTH_ID, commonAuthId);
                 consentCoreService.storeConsentAttributes(consentId, consentAttributes);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentPersistStep.java
@@ -141,6 +141,9 @@ public class ExternalAPIConsentPersistStep implements ConsentPersistStep {
                 if (consentPersistData.getBrowserCookies() != null) {
                     String commonAuthId = consentPersistData.getBrowserCookies().get(
                             ConsentExtensionConstants.COMMON_AUTH_ID);
+                    // Detach the commonAuthId from the consents it is already mapped to, so that only the consent
+                    // being persisted now is resolvable using the commonAuthId of this browser session.
+                    ConsentAuthorizeUtil.removeCommonAuthIdFromExistingConsents(consentCoreService, commonAuthId);
                     consentData.getMetaDataMap().put(ConsentExtensionConstants.COMMON_AUTH_ID, commonAuthId);
                 }
             }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/util/ConsentAuthorizeUtil.java
@@ -30,6 +30,7 @@ import org.json.JSONObject;
 import org.wso2.carbon.identity.oauth.rar.util.AuthorizationDetailsConstants;
 import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants;
+import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.model.AccountDTO;
@@ -41,13 +42,16 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ResponseStatus;
+import org.wso2.financial.services.accelerator.consent.mgt.service.ConsentCoreService;
 
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -933,5 +937,38 @@ public class ConsentAuthorizeUtil {
         isReauthorization = isReauthorization != null && isReauthorization;
 
         consentPersistPayload.put(ConsentAuthorizeConstants.IS_REAUTHORIZATION, Boolean.TRUE.equals(isReauthorization));
+    }
+
+    /**
+     * Remove the commonAuthId consent attribute from any consent it is already mapped to.
+     * <p>
+     * The commonAuthId cookie is issued per browser session, so every authorization performed in the same
+     * browser session carries the same value even if the user logs in again. Since the consent ID bound to the
+     * authorization code is resolved by looking up this attribute, leaving it on previously authorized consents
+     * makes that lookup ambiguous and the wrong consent ID can end up in the access token. Clearing the stale
+     * mappings before the new one is stored keeps exactly one consent mapped to the cookie value.
+     *
+     * @param consentCoreService consent core service
+     * @param commonAuthId       commonAuthId cookie value of the current authorization
+     * @throws ConsentManagementException thrown if an error occurs while retrieving or deleting the attribute
+     */
+    public static void removeCommonAuthIdFromExistingConsents(ConsentCoreService consentCoreService,
+                                                              String commonAuthId)
+            throws ConsentManagementException {
+
+        if (StringUtils.isBlank(commonAuthId)) {
+            return;
+        }
+
+        ArrayList<String> existingConsentIds = consentCoreService.getConsentIdByConsentAttributeNameAndValue(
+                ConsentExtensionConstants.COMMON_AUTH_ID, commonAuthId);
+        for (String existingConsentId : existingConsentIds) {
+            consentCoreService.deleteConsentAttributes(existingConsentId,
+                    new ArrayList<>(Collections.singletonList(ConsentExtensionConstants.COMMON_AUTH_ID)));
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Removed the commonAuthId attribute from consent: %s",
+                        existingConsentId.replaceAll("[\r\n]", "")));
+            }
+        }
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/ConsentAuthorizeUtilTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/ConsentAuthorizeUtilTest.java
@@ -26,20 +26,30 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.financial.services.accelerator.common.config.FinancialServicesConfigParser;
 import org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants;
+import org.wso2.financial.services.accelerator.common.exception.ConsentManagementException;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentResource;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.model.ConsentData;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.authorize.util.ConsentAuthorizeUtil;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
+import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ResponseStatus;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.util.TestConstants;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.util.TestUtil;
+import org.wso2.financial.services.accelerator.consent.mgt.service.ConsentCoreService;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -160,6 +170,51 @@ public class ConsentAuthorizeUtilTest {
                 Collections.singletonList("accounts"), Collections.emptyList());
 
         assertTrue(result);
+    }
+
+    @Test
+    public void testRemoveCommonAuthIdFromExistingConsents() throws ConsentManagementException {
+
+        ConsentCoreService consentCoreServiceMock = mock(ConsentCoreService.class);
+        ArrayList<String> existingConsentIds = new ArrayList<>(Arrays.asList("consent-1", "consent-2"));
+        doReturn(existingConsentIds).when(consentCoreServiceMock).getConsentIdByConsentAttributeNameAndValue(
+                ConsentExtensionConstants.COMMON_AUTH_ID, "sample-common-auth-id");
+
+        ConsentAuthorizeUtil.removeCommonAuthIdFromExistingConsents(consentCoreServiceMock,
+                "sample-common-auth-id");
+
+        ArrayList<String> expectedAttributeKeys = new ArrayList<>(
+                Collections.singletonList(ConsentExtensionConstants.COMMON_AUTH_ID));
+        verify(consentCoreServiceMock).deleteConsentAttributes("consent-1", expectedAttributeKeys);
+        verify(consentCoreServiceMock).deleteConsentAttributes("consent-2", expectedAttributeKeys);
+    }
+
+    @Test
+    public void testRemoveCommonAuthIdFromExistingConsentsWithNoExistingConsents()
+            throws ConsentManagementException {
+
+        ConsentCoreService consentCoreServiceMock = mock(ConsentCoreService.class);
+        doReturn(new ArrayList<String>()).when(consentCoreServiceMock)
+                .getConsentIdByConsentAttributeNameAndValue(ConsentExtensionConstants.COMMON_AUTH_ID,
+                        "sample-common-auth-id");
+
+        ConsentAuthorizeUtil.removeCommonAuthIdFromExistingConsents(consentCoreServiceMock,
+                "sample-common-auth-id");
+
+        verify(consentCoreServiceMock, never()).deleteConsentAttributes(anyString(), any());
+    }
+
+    @Test
+    public void testRemoveCommonAuthIdFromExistingConsentsWithBlankCommonAuthId()
+            throws ConsentManagementException {
+
+        ConsentCoreService consentCoreServiceMock = mock(ConsentCoreService.class);
+
+        ConsentAuthorizeUtil.removeCommonAuthIdFromExistingConsents(consentCoreServiceMock, null);
+        ConsentAuthorizeUtil.removeCommonAuthIdFromExistingConsents(consentCoreServiceMock, "");
+
+        verify(consentCoreServiceMock, never()).getConsentIdByConsentAttributeNameAndValue(anyString(), anyString());
+        verify(consentCoreServiceMock, never()).deleteConsentAttributes(anyString(), any());
     }
 
     private static String decodeRequestObjectPayload(String requestObject) {


### PR DESCRIPTION
## [FS4] Fixes same Common Auth ID issue

> This PR fixes an issue in the non pre initiated consent flow use case where the same consent ID is being added as a claim for 2 different consents when approving consents in the same browser.

The issue is the common Auth ID is the same for a single session even after logging in hence the same common Auth ID is appended to multiple consent

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/1011*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
